### PR TITLE
support simple and complex polygons (with holes)

### DIFF
--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -595,7 +595,7 @@ declare module '@deck.gl/layers/polygon-layer/polygon-layer' {
 	import { COORDINATE_SYSTEM } from '@deck.gl/core';
 	import { Color } from '@deck.gl/core/utils/color';
 	export interface PolygonLayerDatum {
-		polygon?: number[][];
+		polygon?: number[[][]];
 		elevation?: number;
 		fillColor?: number[];
 		lineColor?: number[];
@@ -609,7 +609,7 @@ declare module '@deck.gl/layers/polygon-layer/polygon-layer' {
 		getFillColor?: ((x: PolygonLayerDatum) => Color) | Color;
 		getLineColor?: ((x: PolygonLayerDatum) => Color) | Color;
 		getLineWidth?: ((x: PolygonLayerDatum) => number) | number;
-		getPolygon?: (x: PolygonLayerDatum) => number[][];
+		getPolygon?: (x: PolygonLayerDatum) => number[[][]];
 	}
 	import { CompositeLayer } from '@deck.gl/core';
 	import { LayerProps } from '@deck.gl/core/lib/layer';

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -594,8 +594,9 @@ declare module '@deck.gl/layers/solid-polygon-layer/solid-polygon-layer' {
 declare module '@deck.gl/layers/polygon-layer/polygon-layer' {
 	import { COORDINATE_SYSTEM } from '@deck.gl/core';
 	import { Color } from '@deck.gl/core/utils/color';
+	export type Polygon = number[][] | number[][][];
 	export interface PolygonLayerDatum {
-		polygon?: number[[][]];
+		polygon?: Polygon;
 		elevation?: number;
 		fillColor?: number[];
 		lineColor?: number[];
@@ -609,7 +610,7 @@ declare module '@deck.gl/layers/polygon-layer/polygon-layer' {
 		getFillColor?: ((x: PolygonLayerDatum) => Color) | Color;
 		getLineColor?: ((x: PolygonLayerDatum) => Color) | Color;
 		getLineWidth?: ((x: PolygonLayerDatum) => number) | number;
-		getPolygon?: (x: PolygonLayerDatum) => number[[][]];
+		getPolygon?: (x: PolygonLayerDatum) => Polygon;
 	}
 	import { CompositeLayer } from '@deck.gl/core';
 	import { LayerProps } from '@deck.gl/core/lib/layer';


### PR DESCRIPTION
The polygon field should support both simple and complex polygons:

Example from the [API doc](http://deck.gl/#/documentation/deckgl-api-reference/layers/polygon-layer):
```
   *     // Simple polygon (array of coords)
   *     contour: [[-122.4, 37.7], [-122.4, 37.8], [-122.5, 37.8], [-122.5, 37.7], [-122.4, 37.7]],
   *
   *     // Complex polygon with holes (array of coords)
   *     contour: [
   *       [[-122.4, 37.7], [-122.4, 37.8], [-122.5, 37.8], [-122.5, 37.7], [-122.4, 37.7]],
   *       [[-122.45, 37.73], [-122.47, 37.76], [-122.47, 37.71], [-122.45, 37.73]]
   *     ],
  ```
