### PR TITLE
Add folder deck.gl__aggregation-layers to indefinitely-typed postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node ./scripts/convert.js",
     "test": "tsc -p ./test",
-    "postinstall": "indefinitely-typed --folder deck.gl__core --folder deck.gl__layers --folder deck.gl__google-maps --folder deck.gl__json --folder deck.gl__mapbox --folder deck.gl__mesh-layers --folder deck.gl__geo-layers --folder deck.gl__extensions --folder deck.gl__react --folder deck.gl --folder luma.gl__webgl-state-tracker --folder luma.gl__webgl --folder luma.gl__core --folder math.gl"
+    "postinstall": "indefinitely-typed --folder deck.gl__aggregation-layers --folder deck.gl__core --folder deck.gl__layers --folder deck.gl__google-maps --folder deck.gl__json --folder deck.gl__mapbox --folder deck.gl__mesh-layers --folder deck.gl__geo-layers --folder deck.gl__extensions --folder deck.gl__react --folder deck.gl --folder luma.gl__webgl-state-tracker --folder luma.gl__webgl --folder luma.gl__core --folder math.gl"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@danmarshall I just installed the latest typings and noticed that I'm getting the following error:
```
[error] TypeScript error node_modules/@types/deck.gl/index.d.ts:4:22 - error TS6053: File '<project-folder>/node_modules/@types/deck.gl__aggregation-layers/index.d.ts' not found.

4 /// <reference path="../deck.gl__aggregation-layers/index.d.ts" />
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
node_modules/@types/deck.gl/index.d.ts:73:9 - error TS7016: Could not find a declaration file for module '@deck.gl/aggregation-layers'. '<project-folder>/node_modules/@deck.gl/aggregation-layers/dist/es5/index.js' implicitly has an 'any' type.
  Try `npm install @types/deck.gl__aggregation-layers` if it exists or add a new declaration (.d.ts) file containing `declare module '@deck.gl/aggregation-layers';`

73  } from '@deck.gl/aggregation-layers';
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
This seems to be because the folder `deck.gl__aggregation-layers` hasn't been added to `@types`

![image](https://user-images.githubusercontent.com/26897711/68416886-42be3680-018d-11ea-8d37-5af3460a5f28.png)

even though it's present in the bundle:
![image](https://user-images.githubusercontent.com/26897711/68416607-b3b11e80-018c-11ea-8ef3-0f479f3a25d1.png)

This seems to be due to it being absent from the indefinitely-typed postinstall, see the PR changes

I think this is the correct fix, wanted to throw up a PR to best explain the issue.