### PR TITLE
Add typings for layer props

### DIFF
--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -455,6 +455,7 @@ declare module '@deck.gl/aggregation-layers/utils/cpu-aggregator' {
 declare module '@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface CPUGridLayerProps extends LayerProps, CompositeLayerProps {
         cellSize?: number;
         colorDomain?: Array<any>;
@@ -528,6 +529,7 @@ declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-aggregator' {
 declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface HexagonLayerProps extends LayerProps, CompositeLayerProps {
         radius?: number;
         hexagonAggregator?: Function;
@@ -710,6 +712,7 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer-f
 declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface GPUGridLayerProps extends LayerProps, CompositeLayerProps {
         cellSize?: number;
         colorRange?: Array<any>;
@@ -780,6 +783,7 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer' {
 declare module '@deck.gl/aggregation-layers/grid-layer/grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface GridLayerProps extends LayerProps, CompositeLayerProps {
         cellSize?: number;
         colorDomain?: Array<any>;
@@ -878,6 +882,7 @@ declare module '@deck.gl/aggregation-layers/heatmap-layer/max-vs.glsl' {
 }
 declare module '@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer' {
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface HeatmapLayerProps extends LayerProps, CompositeLayerProps {
         radiusPixels?: number;
         colorRange?: Array<any>;

--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -175,7 +175,21 @@ declare module '@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer-
 }
 declare module '@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ScreenGridLayerProps extends LayerProps {
+        cellSizePixels?: number;
+        cellMarginPixels?: number;
+        minColor?: number;
+        maxColor?: number;
+        colorDomain?: Array<any>;
+        colorRange?: Array<any>;
+        gpuAggregation?: boolean;
+        aggregation?: string;
+        getPosition?: Function;
+        getWeight?: Function;
+    }
 	export default class ScreenGridLayer extends Layer {
+        constructor(props: ScreenGridLayerProps);
 		getShaders(): any;
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
@@ -440,7 +454,34 @@ declare module '@deck.gl/aggregation-layers/utils/cpu-aggregator' {
 }
 declare module '@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface CPUGridLayerProps extends LayerProps, CompositeLayerProps {
+        cellSize?: number;
+        colorDomain?: Array<any>;
+        colorRange?: Array<any>;
+        coverage?: number;
+        elevationDomain?: Array<any>;
+        elevationRange?: Array<any>;
+        elevationScale?: number;
+        extruded?: boolean;
+        upperPercentile?: number;
+        lowerPercentile?: number;
+        elevationUpperPercentile?: number;
+        elevationLowerPercentile?: number;
+        colorScaleType?: string;
+        material?: Object;
+        getPosition?: Function;
+        getColorValue?: Function;
+        getColorWeight?: Function;
+        colorAggregation?: string;
+        getElevationValue?: Function;
+        getElevationWeight?: Function;
+        elevationAggregation?: string;
+        onSetColorDomain?: Function;
+        onSetElevationDomain?: Function;
+    }
 	export default class CPUGridLayer extends CompositeLayer {
+    	constructor(props: CPUGridLayerProps);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -486,7 +527,34 @@ declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-aggregator' {
 }
 declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface HexagonLayerProps extends LayerProps, CompositeLayerProps {
+        radius?: number;
+        hexagonAggregator?: Function;
+        colorDomain?: Array<any>;
+        colorRange?: Array<any>;
+        coverage?: number;
+        elevationDomain?: Array<any>;
+        elevationRange?: Array<any>;
+        elevationScale?: number;
+        extruded?: boolean;
+        upperPercentile?: number;
+        lowerPercentile?: number;
+        elevationUpperPercentile?: number;
+        elevationLowerPercentile?: number;
+        material?: Object;
+        getPosition?: Function;
+        getColorValue?: Function;
+        getColorWeight?: Function;
+        colorAggregation?: string;
+        getElevationValue?: Function;
+        getElevationWeight?: Function;
+        elevationAggregation?: string;
+        onSetColorDomain?: Function;
+        onSetElevationDomain?: Function;
+    }
 	export default class HexagonLayer extends CompositeLayer {
+		constructor(props: HexagonLayerProps);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -589,7 +657,18 @@ declare module '@deck.gl/aggregation-layers/utils/gpu-grid-aggregation/grid-aggr
 }
 declare module '@deck.gl/aggregation-layers/contour-layer/contour-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ContourLayerProps extends LayerProps {
+        cellSize?: number;
+        gpuAggregation?: boolean;
+        contours?: Array<any>;
+        zOffset?: number;
+        fp64?: boolean;
+        getPosition?: Function;
+        getWeight?: Function;
+    }
 	export default class ContourLayer extends CompositeLayer {
+    	constructor(props: ContourLayerProps);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -630,7 +709,26 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer-f
 }
 declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer' {
 	import { Layer } from '@deck.gl/core';
-	export default class GPUGridCellLayer extends Layer {
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface GPUGridLayerProps extends LayerProps, CompositeLayerProps {
+        cellSize?: number;
+        colorRange?: Array<any>;
+        coverage?: number;
+        elevationDomain?: Array<any>;
+        elevationRange?: Array<any>;
+        elevationScale?: number;
+        extruded?: boolean;
+        fp64?: boolean;
+        gpuAggregation?: boolean;
+        material?: Object;
+        getPosition?: Function;
+        getColorWeight?: Function;
+        colorAggregation?: string;
+        getElevationWeight?: Function;
+        elevationAggregation?: string;
+    }
+    export default class GPUGridCellLayer extends Layer {
+    	constructor(props: GPUGridLayerProps);
 		getShaders(): any;
 		initializeState(): void;
 		_getModel(gl: any): any;
@@ -681,7 +779,36 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer' {
 }
 declare module '@deck.gl/aggregation-layers/grid-layer/grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface GridLayerProps extends LayerProps, CompositeLayerProps {
+        cellSize?: number;
+        colorDomain?: Array<any>;
+        colorRange?: Array<any>;
+        coverage?: number;
+        elevationDomain?: Array<any>;
+        elevationRange?: Array<any>;
+        elevationScale?: number;
+        extruded?: boolean;
+        upperPercentile?: number;
+        lowerPercentile?: number;
+        elevationUpperPercentile?: number;
+        elevationLowerPercentile?: number;
+        colorScaleType?: string;
+        fp64?: boolean;
+        gpuAggregation?: boolean;
+        material?: Object;
+        getPosition?: Function;
+        getColorValue?: Function;
+        getColorWeight?: Function;
+        colorAggregation?: string;
+        getElevationValue?: Function;
+        getElevationWeight?: Function;
+        elevationAggregation?: string;
+        onSetColorDomain?: Function;
+        onSetElevationDomain?: Function;
+    }
 	export default class GridLayer extends CompositeLayer {
+    	constructor(props: GridLayerProps);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -750,8 +877,19 @@ declare module '@deck.gl/aggregation-layers/heatmap-layer/max-vs.glsl' {
 
 }
 declare module '@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer' {
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface HeatmapLayerProps extends LayerProps, CompositeLayerProps {
+        radiusPixels?: number;
+        colorRange?: Array<any>;
+        intensity?: number;
+        threshold?: number;
+        colorDomain?: Array<any>;
+        getPosition?: Function;
+        getWeight?: Function;
+    }
 	import { CompositeLayer } from '@deck.gl/core';
 	export default class HeatmapLayer extends CompositeLayer {
+		constructor(props: HeatmapLayerProps);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1064,8 +1064,12 @@ declare module '@deck.gl/core/lib/layer' {
 
 }
 declare module '@deck.gl/core/lib/composite-layer' {
-	import Layer from '@deck.gl/core/lib/layer';
+	import Layer, { LayerProps } from '@deck.gl/core/lib/layer';
+	export interface CompositeLayerProps extends LayerProps {
+        _subLayerProps: Object,
+	}
 	export default class CompositeLayer extends Layer {
+		constructor(props: CompositeLayerProps);
 		readonly isComposite: boolean;
 		getSubLayers(): any;
 		initializeState(): void;

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -104,7 +104,18 @@ declare module '@deck.gl/geo-layers/tile-layer/utils/tile-cache' {
 }
 declare module '@deck.gl/geo-layers/tile-layer/tile-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface TileLayerProps extends LayerProps {
+        maxZoom?: number | null;
+        minZoom?: number;
+        maxCacheSize?: number | null;
+        onViewportLoaded?: Function;
+        getTileData?: Function;
+        onTileError?: Function;
+        renderSubLayers?: Function;
+    }
 	export default class TileLayer extends CompositeLayer {
+    	constructor(props: TileLayerProps);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;
@@ -128,7 +139,16 @@ declare module '@deck.gl/geo-layers/tile-layer/tile-layer' {
 }
 declare module '@deck.gl/geo-layers/trips-layer/trips-layer' {
 	import { PathLayer } from '@deck.gl/layers';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { PathLayerProps } from "@deck.gl/layers/path-layer/path-layer";
+    export interface TripsLayerProps extends PathLayerProps, LayerProps {
+        currentTime?: number;
+        trailLength?: number;
+        getPath?: Function;
+        getTimestamps?: Function;
+    }
 	export default class TripsLayer extends PathLayer {
+		constructor(props: TripsLayerProps);
 		getShaders(): any;
 		initializeState(params: any): void;
 		draw(params: any): void;
@@ -222,7 +242,22 @@ declare module '@deck.gl/geo-layers/tile-3d-layer/get-frame-state' {
 }
 declare module '@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface Tile3DLayerProps extends LayerProps, CompositeLayerProps {
+        opacity?: number;
+        pointSize?: number;
+        data?: string;
+        _ionAssetId?: number | string;
+        _ionAccessToken?: string;
+        loadOptions?: Object;
+        getPointColor?: Function | Array<any>;
+        onTilesetLoad?: Function;
+        onTileLoad?: Function;
+        onTileUnload?: Function;
+        onTileLoadFail?: Function;
+    }
 	export default class Tile3DLayer extends CompositeLayer {
+    	constructor(props: Tile3DLayerProps);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -243,6 +243,7 @@ declare module '@deck.gl/geo-layers/tile-3d-layer/get-frame-state' {
 declare module '@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface Tile3DLayerProps extends LayerProps, CompositeLayerProps {
         opacity?: number;
         pointSize?: number;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -719,6 +719,7 @@ declare module '@deck.gl/layers/geojson-layer/geojson' {
 declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface GeoJsonLayerProps extends LayerProps, CompositeLayerProps {
         filled?: boolean;
         stroked?: boolean;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -10,8 +10,23 @@ declare module '@deck.gl/layers/arc-layer/arc-layer-fragment.glsl' {
 
 }
 declare module '@deck.gl/layers/arc-layer/arc-layer' {
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ArcLayerProps extends LayerProps {
+        widthUnits?: string;
+        widthScale?: number;
+        widthMinPixels?: number;
+        widthMaxPixels?: number;
+        getSourcePosition?: Function;
+        getTargetPosition?: Function;
+        getSourceColor?: Function | Array<any>;
+        getTargetColor?: Function | Array<any>;
+        getWidth?: Function | number;
+        getHeight?: Function | number;
+        getTilt?: Function | number;
+    }
 	import { Layer } from '@deck.gl/core';
 	export default class ArcLayer extends Layer {
+		constructor(props: ArcLayerProps)
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -42,7 +57,16 @@ declare module '@deck.gl/layers/bitmap-layer/bitmap-layer-fragment' {
 }
 declare module '@deck.gl/layers/bitmap-layer/bitmap-layer' {
 	import { Layer } from '@deck.gl/core';
+    export interface BitmapLayerProps extends LayerProps {
+        bitmap: any
+        bounds: Array<any>
+        desaturate: number
+        transparentColor: Array<any>
+        tintColor: Array<any>
+    }
+    import { LayerProps } from "@deck.gl/core/lib/layer";
 	export default class BitmapLayer extends Layer {
+		constructor(props: BitmapLayerProps)
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -281,7 +305,17 @@ declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer-fragment.gls
 }
 declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface PointCloudLayerProps extends LayerProps {
+        sizeUnits?: string;
+        pointSize?: number;
+        material?: Object;
+        getPosition?: Function;
+        getNormal?: Function | Array<any>;
+        getColor?: Function | Array<any>;
+    }
 	export default class PointCloudLayer extends Layer {
+    	constructor(props: PointCloudLayerProps);
 		getShaders(id: any): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -308,7 +342,26 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer-fragment.gls
 }
 declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ScatterplotLayerProps extends LayerProps {
+        radiusScale?: number;
+        lineWidthUnits?: string;
+        lineWidthScale?: number;
+        stroked?: boolean;
+        filled?: boolean;
+        radiusMinPixels?: number;
+        radiusMaxPixels?: number;
+        lineWidthMinPixels?: number;
+        lineWidthMaxPixels?: number;
+        getPosition?: Function;
+        getRadius?: Function | number;
+        getColor?: Function | Array<any>;
+        getFillColor?: Function | Array<any>;
+        getLineColor?: Function | Array<any>;
+        getLineWidth?: Function | Array<any>;
+    }
 	export default class ScatterplotLayer extends Layer {
+    	constructor(props: ScatterplotLayerProps);
 		getShaders(id: any): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -343,7 +396,33 @@ declare module '@deck.gl/layers/column-layer/column-layer-fragment.glsl' {
 declare module '@deck.gl/layers/column-layer/column-layer' {
 	import { Layer } from '@deck.gl/core';
 	import ColumnGeometry from '@deck.gl/layers/column-layer/column-geometry';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+	export interface ColumnLayerProps extends LayerProps {
+        diskResolution?: number;
+        radius?: number;
+        angle?: number;
+        vertices?: Array<any>;
+        offset?: number;
+        coverage?: number;
+        elevationScale?: number;
+        filled?: boolean;
+        filled?: boolean;
+        stroked?: boolean;
+        extruded?: boolean;
+        wireframe?: boolean;
+        lineWidthUnits?: string;
+        lineWidthScale?: boolean;
+        lineWidthMinPixels?: number;
+        lineWidthMaxPixels?: number;
+        material?: Object;
+        getPosition?: Function;
+        getFillColor?: Function | Array<any>;
+        getLineColor?: Function | Array<any>;
+        getElevation?: Function | number;
+        getLineWidth?: Function | number;
+    }
 	export default class ColumnLayer extends Layer {
+		constructor(props: ColumnLayerProps);
 		getShaders(): any;
 	    /**
 	     * DeckGL calls initializeState when GL context is available
@@ -369,7 +448,19 @@ declare module '@deck.gl/layers/column-layer/column-layer' {
 }
 declare module '@deck.gl/layers/column-layer/grid-cell-layer' {
 	import ColumnLayer from '@deck.gl/layers/column-layer/column-layer';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface GridCellLayerProps extends LayerProps {
+        cellSize?: number;
+        coverage?: number;
+        elevationScale?: number;
+        extruded?: boolean;
+        material?: Object;
+        getPosition?: Function;
+        getColor?: Function | Array<any>;
+        getElevation?: Function | number;
+    }
 	export default class GridCellLayer extends ColumnLayer {
+    	constructor(props: GridCellLayerProps);
 		getGeometry(diskResolution: any): any;
 		draw({ uniforms }: {
 			uniforms: any;
@@ -407,7 +498,23 @@ declare module '@deck.gl/layers/path-layer/path-layer-fragment.glsl' {
 }
 declare module '@deck.gl/layers/path-layer/path-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface PathLayerProps extends LayerProps {
+        widthUnits?: string;
+        widthScale?: number;
+        widthMinPixels?: number;
+        widthMaxPixels?: number;
+        rounded?: boolean;
+        billboard?: boolean;
+        miterLimit?: number;
+        dashJustified?: boolean;
+        getPath?: Function;
+        getColor?: Function | Array<any>;
+        getWidth?: Function | number;
+        getDashArray?: Function | Array<any>;
+    }
 	export default class PathLayer extends Layer {
+    	constructor(props: PathLayerProps);
 		getShaders(): any;
 		initializeState(params?: any): void;
 		updateState({ oldProps, props, changeFlags }: {
@@ -611,7 +718,33 @@ declare module '@deck.gl/layers/geojson-layer/geojson' {
 }
 declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface GeoJsonLayerProps extends LayerProps, CompositeLayerProps {
+        filled?: boolean;
+        stroked?: boolean;
+        extruded?: boolean;
+        wireframe?: boolean;
+        lineWidthUnits?: string;
+        lineWidthScale?: number;
+        lineWidthMinPixels?: number;
+        lineWidthMaxPixels?: number;
+        lineJointRounded?: boolean;
+        lineMiterLimit?: number;
+        elevationScale?: number;
+        pointRadiusScale?: number;
+        pointRadiusMinPixels?: number;
+        pointRadiusMaxPixels?: number;
+        lineDashJustified?: boolean;
+        material?: Object;
+        getLineColor?: Function | Array<any>;
+        getFillColor?: Function | Array<any>;
+        getRadius?: Function | number;
+        getLineWidth?: Function | number;
+        getElevation?: Function | number;
+        getLineDashArray?: Function | Array<any>;
+    }
 	export default class GeoJsonLayer extends CompositeLayer {
+    	constructor(props: GeoJsonLayerProps);
 		initializeState(): void;
 		updateState({ props, changeFlags }: {
 			props: any;

--- a/deck.gl__mesh-layers/index.d.ts
+++ b/deck.gl__mesh-layers/index.d.ts
@@ -54,7 +54,22 @@ declare module '@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer-fragmen
 }
 declare module '@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface SimpleMeshLayerProps extends LayerProps {
+        mesh: any;
+        texture?: any;
+        sizeScale?: number;
+        wireframe?: boolean;
+        material?: Object;
+        getPosition?: Function;
+        getColor?: Function | Array<any>;
+        getOrientation?: Function | Array<any>;
+        getScale?: Function | Array<any>;
+        getTranslation?: Function | Array<any>;
+        getTransformMatrix?: Function | Array<any>;
+    }
 	export default class SimpleMeshLayer extends Layer {
+    	constructor(props: SimpleMeshLayerProps);
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -87,7 +102,24 @@ declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer-fragment.
 }
 declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ScenegraphLayerProps extends LayerProps {
+        scenegraph: URL | Object | Promise<any>;
+        sizeScale?: number;
+        _animations?: Object;
+        getScene?: Function;
+        getAnimator?: Function;
+        _lighting?: string;
+        _imageBasedLightingEnvironment?: any
+        getPosition?: Function;
+        getColor?: Function | Array<any>;
+        getOrientation?: Function | Array<any>;
+        getScale?: Function | Array<any>;
+        getTranslation?: Function | Array<any>;
+        getTransformMatrix?: Function | Array<any>;
+    }
 	export default class ScenegraphLayer extends Layer {
+    	constructor(props: ScenegraphLayerProps);
 		initializeState(): void;
 		updateState(params: any): void;
 		finalizeState(): void;


### PR DESCRIPTION
Hey @danmarshall I generated these from the documentation. I haven't committed the generation code as it only got me like 95% of the way and automating the last mile would be a lot of effort.
I think they're all legit and I'll test a couple of them in my project.

I left a lot of them as pretty naive typings but at least this gets the bulk of the effort done, people can tweak themselves to get better types. It at least stops things like the below:

```
const layer = new HeatmapLayer({
    ...
  } as any);
```