### PR TITLE
Mhawes/improve layers typings

### DIFF
--- a/deck.gl/index.d.ts
+++ b/deck.gl/index.d.ts
@@ -71,7 +71,7 @@ declare module 'deck.gl' {
 		GPUGridLayer,
 		AGGREGATION_OPERATION,
 		HeatmapLayer,
-        DeckGLColor,
+        RGBAColor,
 		ColorDomain,
 		ColorRange,
 	} from '@deck.gl/aggregation-layers';

--- a/deck.gl/index.d.ts
+++ b/deck.gl/index.d.ts
@@ -44,7 +44,8 @@ declare module 'deck.gl' {
 		DirectionalLight,
 		LayerExtension,
 		fp64LowPart,
-		createIterable
+		createIterable,
+        DeckProps,
 	} from '@deck.gl/core';
 	export {
 		ArcLayer,
@@ -69,7 +70,10 @@ declare module 'deck.gl' {
 		GridLayer,
 		GPUGridLayer,
 		AGGREGATION_OPERATION,
-		HeatmapLayer
+		HeatmapLayer,
+        DeckGLColor,
+		ColorDomain,
+		ColorRange,
 	} from '@deck.gl/aggregation-layers';
 	export {
 		GreatCircleLayer,

--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -946,6 +946,7 @@ declare module '@deck.gl/aggregation-layers' {
 	export { AGGREGATION_OPERATION } from '@deck.gl/aggregation-layers/utils/aggregation-operation-utils';
 	export { default as HeatmapLayer } from '@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer';
 	export { default as _GPUGridAggregator } from '@deck.gl/aggregation-layers/utils/gpu-grid-aggregation/gpu-grid-aggregator';
+	export { DeckGLColor, ColorDomain, ColorRange } from '@deck.gl/aggregation-layers/utils/color-utils';
 	import { default as BinSorter } from '@deck.gl/aggregation-layers/utils/bin-sorter';
 	import { linearScale, getLinearScale, quantizeScale, getQuantizeScale, getQuantileScale, getOrdinalScale } from '@deck.gl/aggregation-layers/utils/scale-utils';
 	export const experimental: {

--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -455,6 +455,7 @@ declare module '@deck.gl/aggregation-layers/utils/cpu-aggregator' {
 declare module '@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface CPUGridLayerProps extends LayerProps, CompositeLayerProps {
         cellSize?: number;
         colorDomain?: Array<any>;
@@ -528,6 +529,7 @@ declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-aggregator' {
 declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface HexagonLayerProps extends LayerProps, CompositeLayerProps {
         radius?: number;
         hexagonAggregator?: Function;
@@ -710,6 +712,7 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer-f
 declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface GPUGridLayerProps extends LayerProps, CompositeLayerProps {
         cellSize?: number;
         colorRange?: Array<any>;
@@ -780,6 +783,7 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer' {
 declare module '@deck.gl/aggregation-layers/grid-layer/grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface GridLayerProps extends LayerProps, CompositeLayerProps {
         cellSize?: number;
         colorDomain?: Array<any>;
@@ -878,6 +882,7 @@ declare module '@deck.gl/aggregation-layers/heatmap-layer/max-vs.glsl' {
 }
 declare module '@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer' {
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface HeatmapLayerProps extends LayerProps, CompositeLayerProps {
         radiusPixels?: number;
         colorRange?: Array<any>;

--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -672,8 +672,8 @@ declare module '@deck.gl/aggregation-layers/contour-layer/contour-layer' {
         getPosition?: (d: D) => [number, number];
         getWeight?: (d: D) => number;
     }
-	export default class ContourLayer extends CompositeLayer {
-    	constructor(props: ContourLayerProps);
+	export default class ContourLayer<D> extends CompositeLayer<D> {
+    	constructor(props: ContourLayerProps<D>);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -760,7 +760,9 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer' 
 }
 declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-	export default class GPUGridLayer extends CompositeLayer {
+    import { GPUGridLayerProps } from "@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer";
+	export default class GPUGridLayer<D> extends CompositeLayer<D> {
+		constructor(props: GPUGridLayerProps<D>)
 		initializeState(): void;
 		updateState(opts: any): void;
 		finalizeState(): void;
@@ -858,7 +860,9 @@ declare module '@deck.gl/aggregation-layers/heatmap-layer/triangle-layer-fragmen
 }
 declare module '@deck.gl/aggregation-layers/heatmap-layer/triangle-layer' {
 	import { Layer } from '@deck.gl/core';
-	export default class TriangleLayer extends Layer {
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+	export default class TriangleLayer<D> extends Layer<D> {
+		constructor(props: LayerProps<D>)
 		getShaders(): {
 			vs: string;
 			fs: string;

--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -2,7 +2,9 @@
 declare module '@deck.gl/aggregation-layers/utils/color-utils' {
 	export const defaultColorRange: number[][];
 	export function colorRangeToFlatArray(colorRange: any, normalize?: boolean, ArrayType?: Float32ArrayConstructor): any;
-
+    export type DeckGLColor = [number, number, number, number?];
+    export type ColorDomain = [number, number];
+    export type ColorRange = [DeckGLColor, DeckGLColor, DeckGLColor, DeckGLColor, DeckGLColor, DeckGLColor]
 }
 declare module '@deck.gl/aggregation-layers/utils/aggregation-operation-utils' {
 	export const AGGREGATION_OPERATION: {
@@ -176,20 +178,21 @@ declare module '@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer-
 declare module '@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface ScreenGridLayerProps extends LayerProps {
+    import { ColorDomain, ColorRange, DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    export interface ScreenGridLayerProps<D> extends LayerProps<D> {
         cellSizePixels?: number;
         cellMarginPixels?: number;
-        minColor?: number;
-        maxColor?: number;
-        colorDomain?: Array<any>;
-        colorRange?: Array<any>;
+        minColor?: DeckGLColor;
+        maxColor?: DeckGLColor;
+        colorDomain?: ColorDomain;
+        colorRange?: ColorRange;
         gpuAggregation?: boolean;
         aggregation?: string;
-        getPosition?: Function;
-        getWeight?: Function;
+        getPosition?: (d: D) => [number, number];
+        getWeight?: (d: D) => number;
     }
-	export default class ScreenGridLayer extends Layer {
-        constructor(props: ScreenGridLayerProps);
+	export default class ScreenGridLayer<D> extends Layer<D> {
+        constructor(props: ScreenGridLayerProps<D>);
 		getShaders(): any;
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
@@ -454,15 +457,16 @@ declare module '@deck.gl/aggregation-layers/utils/cpu-aggregator' {
 }
 declare module '@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-    import { LayerProps } from "@deck.gl/core/lib/layer";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-    export interface CPUGridLayerProps extends LayerProps, CompositeLayerProps {
+    import { ColorDomain, ColorRange } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { ElevationDomain, ElevationRange } from "@deck.gl/layers/elevation";
+    export interface CPUGridLayerProps<D> extends CompositeLayerProps<D> {
         cellSize?: number;
-        colorDomain?: Array<any>;
-        colorRange?: Array<any>;
+        colorDomain?: ColorDomain;
+        colorRange?: ColorRange;
         coverage?: number;
-        elevationDomain?: Array<any>;
-        elevationRange?: Array<any>;
+        elevationDomain?: ElevationDomain;
+        elevationRange?: ElevationRange;
         elevationScale?: number;
         extruded?: boolean;
         upperPercentile?: number;
@@ -471,18 +475,18 @@ declare module '@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer' {
         elevationLowerPercentile?: number;
         colorScaleType?: string;
         material?: Object;
-        getPosition?: Function;
-        getColorValue?: Function;
-        getColorWeight?: Function;
+        getPosition?: (d: D) => [number, number];
+        getColorValue?: (d: D[]) => number;
+        getColorWeight?: (d: D) => number;
         colorAggregation?: string;
-        getElevationValue?: Function;
-        getElevationWeight?: Function;
+        getElevationValue?: (points: D[]) => number;
+        getElevationWeight?: (d: D) => number;
         elevationAggregation?: string;
-        onSetColorDomain?: Function;
-        onSetElevationDomain?: Function;
+        onSetColorDomain?: () => void;
+        onSetElevationDomain?: () => void;
     }
-	export default class CPUGridLayer extends CompositeLayer {
-    	constructor(props: CPUGridLayerProps);
+	export default class CPUGridLayer<D> extends CompositeLayer<D> {
+    	constructor(props: CPUGridLayerProps<D>);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -528,9 +532,8 @@ declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-aggregator' {
 }
 declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-    import { LayerProps } from "@deck.gl/core/lib/layer";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-    export interface HexagonLayerProps extends LayerProps, CompositeLayerProps {
+    export interface HexagonLayerProps<D> extends CompositeLayerProps<D> {
         radius?: number;
         hexagonAggregator?: Function;
         colorDomain?: Array<any>;
@@ -545,18 +548,18 @@ declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer' {
         elevationUpperPercentile?: number;
         elevationLowerPercentile?: number;
         material?: Object;
-        getPosition?: Function;
-        getColorValue?: Function;
-        getColorWeight?: Function;
+        getPosition?: (d: D) => [number, number];
+        getColorValue?: (d: D) => any;
+        getColorWeight?: (d: D) => any;
         colorAggregation?: string;
-        getElevationValue?: Function;
-        getElevationWeight?: Function;
+        getElevationValue?: (d: D) => any;
+        getElevationWeight?: (d: D) => any;
         elevationAggregation?: string;
         onSetColorDomain?: Function;
         onSetElevationDomain?: Function;
     }
-	export default class HexagonLayer extends CompositeLayer {
-		constructor(props: HexagonLayerProps);
+	export default class HexagonLayer<D> extends CompositeLayer<D> {
+		constructor(props: HexagonLayerProps<D>);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -660,14 +663,14 @@ declare module '@deck.gl/aggregation-layers/utils/gpu-grid-aggregation/grid-aggr
 declare module '@deck.gl/aggregation-layers/contour-layer/contour-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface ContourLayerProps extends LayerProps {
+    export interface ContourLayerProps<D> extends LayerProps<D> {
         cellSize?: number;
         gpuAggregation?: boolean;
         contours?: Array<any>;
         zOffset?: number;
         fp64?: boolean;
-        getPosition?: Function;
-        getWeight?: Function;
+        getPosition?: (d: D) => [number, number];
+        getWeight?: (d: D) => number;
     }
 	export default class ContourLayer extends CompositeLayer {
     	constructor(props: ContourLayerProps);
@@ -711,27 +714,29 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer-f
 }
 declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer' {
 	import { Layer } from '@deck.gl/core';
-    import { LayerProps } from "@deck.gl/core/lib/layer";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-    export interface GPUGridLayerProps extends LayerProps, CompositeLayerProps {
+    import { ColorRange } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { ElevationDomain, ElevationRange } from "@deck.gl/layers/elevation";
+    import PhongMaterial from "@luma.gl/core/materials/phong-material";
+    export interface GPUGridLayerProps<D> extends CompositeLayerProps<D> {
         cellSize?: number;
-        colorRange?: Array<any>;
+        colorRange?: ColorRange;
         coverage?: number;
-        elevationDomain?: Array<any>;
-        elevationRange?: Array<any>;
+        elevationDomain?: ElevationDomain;
+        elevationRange?: ElevationRange;
         elevationScale?: number;
         extruded?: boolean;
         fp64?: boolean;
         gpuAggregation?: boolean;
-        material?: Object;
-        getPosition?: Function;
-        getColorWeight?: Function;
+        material?: PhongMaterial;
+        getPosition?: (d: D) => [number, number];
+        getColorWeight?: (d: D) => number;
         colorAggregation?: string;
-        getElevationWeight?: Function;
+        getElevationWeight?: (d: D) => number;
         elevationAggregation?: string;
     }
-    export default class GPUGridCellLayer extends Layer {
-    	constructor(props: GPUGridLayerProps);
+    export default class GPUGridCellLayer<D> extends Layer<D> {
+    	constructor(props: GPUGridLayerProps<D>);
 		getShaders(): any;
 		initializeState(): void;
 		_getModel(gl: any): any;
@@ -782,15 +787,17 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer' {
 }
 declare module '@deck.gl/aggregation-layers/grid-layer/grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-    import { LayerProps } from "@deck.gl/core/lib/layer";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-    export interface GridLayerProps extends LayerProps, CompositeLayerProps {
+    import { ColorDomain, ColorRange } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { ElevationDomain, ElevationRange } from "@deck.gl/layers/elevation";
+    import PhongMaterial from "@luma.gl/core/materials/phong-material";
+    export interface GridLayerProps<D> extends CompositeLayerProps<D> {
         cellSize?: number;
-        colorDomain?: Array<any>;
-        colorRange?: Array<any>;
+        colorDomain?: ColorDomain;
+        colorRange?: ColorRange;
         coverage?: number;
-        elevationDomain?: Array<any>;
-        elevationRange?: Array<any>;
+        elevationDomain?: ElevationDomain;
+        elevationRange?: ElevationRange;
         elevationScale?: number;
         extruded?: boolean;
         upperPercentile?: number;
@@ -800,19 +807,19 @@ declare module '@deck.gl/aggregation-layers/grid-layer/grid-layer' {
         colorScaleType?: string;
         fp64?: boolean;
         gpuAggregation?: boolean;
-        material?: Object;
-        getPosition?: Function;
-        getColorValue?: Function;
-        getColorWeight?: Function;
+        material?: PhongMaterial;
+        getPosition?: (d: D) => [number, number];
+        getColorValue?: (points: D[]) => number;
+        getColorWeight?: (d: D) => number;
         colorAggregation?: string;
-        getElevationValue?: Function;
-        getElevationWeight?: Function;
+        getElevationValue?: (points: D[]) => number;
+        getElevationWeight?: (d: D) => number;
         elevationAggregation?: string;
-        onSetColorDomain?: Function;
-        onSetElevationDomain?: Function;
+        onSetColorDomain?: () => void;
+        onSetElevationDomain?: () => void;
     }
-	export default class GridLayer extends CompositeLayer {
-    	constructor(props: GridLayerProps);
+	export default class GridLayer<D> extends CompositeLayer<D> {
+    	constructor(props: GridLayerProps<D>);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -881,20 +888,20 @@ declare module '@deck.gl/aggregation-layers/heatmap-layer/max-vs.glsl' {
 
 }
 declare module '@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer' {
-    import { LayerProps } from "@deck.gl/core/lib/layer";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-    export interface HeatmapLayerProps extends LayerProps, CompositeLayerProps {
+    export interface HeatmapLayerProps<D> extends CompositeLayerProps<D> {
         radiusPixels?: number;
-        colorRange?: Array<any>;
+        colorRange?: ColorRange;
         intensity?: number;
         threshold?: number;
-        colorDomain?: Array<any>;
-        getPosition?: Function;
-        getWeight?: Function;
+        colorDomain?: ColorDomain;
+        getPosition?: (d: D) => [number, number];
+        getWeight?: (d: D) => number;
     }
 	import { CompositeLayer } from '@deck.gl/core';
-	export default class HeatmapLayer extends CompositeLayer {
-		constructor(props: HeatmapLayerProps);
+    import { ColorDomain, ColorRange } from "@deck.gl/aggregation-layers/utils/color-utils";
+	export default class HeatmapLayer<D> extends CompositeLayer<D> {
+		constructor(props: HeatmapLayerProps<D>);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;

--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -2,9 +2,9 @@
 declare module '@deck.gl/aggregation-layers/utils/color-utils' {
 	export const defaultColorRange: number[][];
 	export function colorRangeToFlatArray(colorRange: any, normalize?: boolean, ArrayType?: Float32ArrayConstructor): any;
-    export type DeckGLColor = [number, number, number, number?];
+    export type RGBAColor = [number, number, number, number?];
     export type ColorDomain = [number, number];
-    export type ColorRange = [DeckGLColor, DeckGLColor, DeckGLColor, DeckGLColor, DeckGLColor, DeckGLColor]
+    export type ColorRange = [RGBAColor, RGBAColor, RGBAColor, RGBAColor, RGBAColor, RGBAColor]
 }
 declare module '@deck.gl/aggregation-layers/utils/aggregation-operation-utils' {
 	export const AGGREGATION_OPERATION: {
@@ -178,12 +178,12 @@ declare module '@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer-
 declare module '@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    import { ColorDomain, ColorRange, DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { ColorDomain, ColorRange, RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     export interface ScreenGridLayerProps<D> extends LayerProps<D> {
         cellSizePixels?: number;
         cellMarginPixels?: number;
-        minColor?: DeckGLColor;
-        maxColor?: DeckGLColor;
+        minColor?: RGBAColor;
+        maxColor?: RGBAColor;
         colorDomain?: ColorDomain;
         colorRange?: ColorRange;
         gpuAggregation?: boolean;
@@ -946,7 +946,7 @@ declare module '@deck.gl/aggregation-layers' {
 	export { AGGREGATION_OPERATION } from '@deck.gl/aggregation-layers/utils/aggregation-operation-utils';
 	export { default as HeatmapLayer } from '@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer';
 	export { default as _GPUGridAggregator } from '@deck.gl/aggregation-layers/utils/gpu-grid-aggregation/gpu-grid-aggregator';
-	export { DeckGLColor, ColorDomain, ColorRange } from '@deck.gl/aggregation-layers/utils/color-utils';
+	export { RGBAColor, ColorDomain, ColorRange } from '@deck.gl/aggregation-layers/utils/color-utils';
 	import { default as BinSorter } from '@deck.gl/aggregation-layers/utils/bin-sorter';
 	import { linearScale, getLinearScale, quantizeScale, getQuantizeScale, getQuantileScale, getOrdinalScale } from '@deck.gl/aggregation-layers/utils/scale-utils';
 	export const experimental: {

--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -175,7 +175,21 @@ declare module '@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer-
 }
 declare module '@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ScreenGridLayerProps extends LayerProps {
+        cellSizePixels?: number;
+        cellMarginPixels?: number;
+        minColor?: number;
+        maxColor?: number;
+        colorDomain?: Array<any>;
+        colorRange?: Array<any>;
+        gpuAggregation?: boolean;
+        aggregation?: string;
+        getPosition?: Function;
+        getWeight?: Function;
+    }
 	export default class ScreenGridLayer extends Layer {
+        constructor(props: ScreenGridLayerProps);
 		getShaders(): any;
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
@@ -440,7 +454,34 @@ declare module '@deck.gl/aggregation-layers/utils/cpu-aggregator' {
 }
 declare module '@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface CPUGridLayerProps extends LayerProps, CompositeLayerProps {
+        cellSize?: number;
+        colorDomain?: Array<any>;
+        colorRange?: Array<any>;
+        coverage?: number;
+        elevationDomain?: Array<any>;
+        elevationRange?: Array<any>;
+        elevationScale?: number;
+        extruded?: boolean;
+        upperPercentile?: number;
+        lowerPercentile?: number;
+        elevationUpperPercentile?: number;
+        elevationLowerPercentile?: number;
+        colorScaleType?: string;
+        material?: Object;
+        getPosition?: Function;
+        getColorValue?: Function;
+        getColorWeight?: Function;
+        colorAggregation?: string;
+        getElevationValue?: Function;
+        getElevationWeight?: Function;
+        elevationAggregation?: string;
+        onSetColorDomain?: Function;
+        onSetElevationDomain?: Function;
+    }
 	export default class CPUGridLayer extends CompositeLayer {
+    	constructor(props: CPUGridLayerProps);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -486,7 +527,34 @@ declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-aggregator' {
 }
 declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface HexagonLayerProps extends LayerProps, CompositeLayerProps {
+        radius?: number;
+        hexagonAggregator?: Function;
+        colorDomain?: Array<any>;
+        colorRange?: Array<any>;
+        coverage?: number;
+        elevationDomain?: Array<any>;
+        elevationRange?: Array<any>;
+        elevationScale?: number;
+        extruded?: boolean;
+        upperPercentile?: number;
+        lowerPercentile?: number;
+        elevationUpperPercentile?: number;
+        elevationLowerPercentile?: number;
+        material?: Object;
+        getPosition?: Function;
+        getColorValue?: Function;
+        getColorWeight?: Function;
+        colorAggregation?: string;
+        getElevationValue?: Function;
+        getElevationWeight?: Function;
+        elevationAggregation?: string;
+        onSetColorDomain?: Function;
+        onSetElevationDomain?: Function;
+    }
 	export default class HexagonLayer extends CompositeLayer {
+		constructor(props: HexagonLayerProps);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -589,7 +657,18 @@ declare module '@deck.gl/aggregation-layers/utils/gpu-grid-aggregation/grid-aggr
 }
 declare module '@deck.gl/aggregation-layers/contour-layer/contour-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ContourLayerProps extends LayerProps {
+        cellSize?: number;
+        gpuAggregation?: boolean;
+        contours?: Array<any>;
+        zOffset?: number;
+        fp64?: boolean;
+        getPosition?: Function;
+        getWeight?: Function;
+    }
 	export default class ContourLayer extends CompositeLayer {
+    	constructor(props: ContourLayerProps);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -630,7 +709,26 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer-f
 }
 declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-cell-layer' {
 	import { Layer } from '@deck.gl/core';
-	export default class GPUGridCellLayer extends Layer {
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface GPUGridLayerProps extends LayerProps, CompositeLayerProps {
+        cellSize?: number;
+        colorRange?: Array<any>;
+        coverage?: number;
+        elevationDomain?: Array<any>;
+        elevationRange?: Array<any>;
+        elevationScale?: number;
+        extruded?: boolean;
+        fp64?: boolean;
+        gpuAggregation?: boolean;
+        material?: Object;
+        getPosition?: Function;
+        getColorWeight?: Function;
+        colorAggregation?: string;
+        getElevationWeight?: Function;
+        elevationAggregation?: string;
+    }
+    export default class GPUGridCellLayer extends Layer {
+    	constructor(props: GPUGridLayerProps);
 		getShaders(): any;
 		initializeState(): void;
 		_getModel(gl: any): any;
@@ -681,7 +779,36 @@ declare module '@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer' {
 }
 declare module '@deck.gl/aggregation-layers/grid-layer/grid-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface GridLayerProps extends LayerProps, CompositeLayerProps {
+        cellSize?: number;
+        colorDomain?: Array<any>;
+        colorRange?: Array<any>;
+        coverage?: number;
+        elevationDomain?: Array<any>;
+        elevationRange?: Array<any>;
+        elevationScale?: number;
+        extruded?: boolean;
+        upperPercentile?: number;
+        lowerPercentile?: number;
+        elevationUpperPercentile?: number;
+        elevationLowerPercentile?: number;
+        colorScaleType?: string;
+        fp64?: boolean;
+        gpuAggregation?: boolean;
+        material?: Object;
+        getPosition?: Function;
+        getColorValue?: Function;
+        getColorWeight?: Function;
+        colorAggregation?: string;
+        getElevationValue?: Function;
+        getElevationWeight?: Function;
+        elevationAggregation?: string;
+        onSetColorDomain?: Function;
+        onSetElevationDomain?: Function;
+    }
 	export default class GridLayer extends CompositeLayer {
+    	constructor(props: GridLayerProps);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -750,8 +877,19 @@ declare module '@deck.gl/aggregation-layers/heatmap-layer/max-vs.glsl' {
 
 }
 declare module '@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer' {
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface HeatmapLayerProps extends LayerProps, CompositeLayerProps {
+        radiusPixels?: number;
+        colorRange?: Array<any>;
+        intensity?: number;
+        threshold?: number;
+        colorDomain?: Array<any>;
+        getPosition?: Function;
+        getWeight?: Function;
+    }
 	import { CompositeLayer } from '@deck.gl/core';
 	export default class HeatmapLayer extends CompositeLayer {
+		constructor(props: HeatmapLayerProps);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1064,8 +1064,12 @@ declare module '@deck.gl/core/lib/layer' {
 
 }
 declare module '@deck.gl/core/lib/composite-layer' {
-	import Layer from '@deck.gl/core/lib/layer';
+	import Layer, { LayerProps } from '@deck.gl/core/lib/layer';
+	export interface CompositeLayerProps extends LayerProps {
+        _subLayerProps: Object,
+	}
 	export default class CompositeLayer extends Layer {
+		constructor(props: CompositeLayerProps);
 		readonly isComposite: boolean;
 		getSubLayers(): any;
 		initializeState(): void;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -937,8 +937,8 @@ declare module '@deck.gl/core/lib/layer' {
 	import AttributeManager from '@deck.gl/core/lib/attribute-manager';
 	import Component from '@deck.gl/core/lifecycle/component';
 	import { PickInfo } from '@deck.gl/core/lib/deck';
-	import { Color } from '@deck.gl/core/utils/color';
 	import * as hammerjs from 'hammerjs';
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 	export interface TransitionTiming {
 		duration?: number;
 		easing?: (t: number) => number;
@@ -954,19 +954,23 @@ declare module '@deck.gl/core/lib/layer' {
 	export interface LayerInputHandler {
 		(o: PickInfo, e: HammerInput): void;
 	}
-	export interface LayerProps {
+	export type DataSet<D> = Iterable<D>;
+		// | AsyncIterable ToDo: Add AsyncIterable
+		// | { length: number } Todo: Support non-iterable objects, see deck.gl docs: /docs/developer-guide/using-layers.md#accessors
+	export interface LayerProps<D> {
 		coordinateSystem?: number;
 		id?: string;
+		data?: DataSet<D> | Promise<DataSet<D>> | string;
 		transitions?: { [attributeGetter: string]: TransitionTiming };
 		pickable?: boolean;
 		autoHighlight?: boolean;
-		highlightColor?: Color;
+		highlightColor?: DeckGLColor;
 		onClick?: LayerInputHandler;
 		onHover?: LayerInputHandler;
 		lightSettings?: LightSettings;
 	}
-	export default class Layer extends Component {
-		constructor(props: LayerProps);
+	export default class Layer<D> extends Component {
+		constructor(props: LayerProps<D>);
 		toString(): string;
 		setState(updateObject: any): void;
 		setNeedsRedraw(redraw?: boolean): void;
@@ -991,8 +995,8 @@ declare module '@deck.gl/core/lib/layer' {
 		use64bitPositions(): boolean;
 		onHover(info: any, pickingEvent: any): any;
 		onClick(info: any, pickingEvent: any): any;
-		nullPickingColor(): Color;
-		encodePickingColor(i: any, target?: any[]): Color;
+		nullPickingColor(): DeckGLColor;
+		encodePickingColor(i: any, target?: any[]): DeckGLColor;
 		decodePickingColor(color: any): number;
 		initializeState(): void;
 		getShaders(shaders: any): any;
@@ -1065,11 +1069,11 @@ declare module '@deck.gl/core/lib/layer' {
 }
 declare module '@deck.gl/core/lib/composite-layer' {
 	import Layer, { LayerProps } from '@deck.gl/core/lib/layer';
-	export interface CompositeLayerProps extends LayerProps {
+	export interface CompositeLayerProps<D> extends LayerProps<D> {
         _subLayerProps: Object,
 	}
-	export default class CompositeLayer extends Layer {
-		constructor(props: CompositeLayerProps);
+	export default class CompositeLayer<D> extends Layer<D> {
+		constructor(props: CompositeLayerProps<D>);
 		readonly isComposite: boolean;
 		getSubLayers(): any;
 		initializeState(): void;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -938,7 +938,7 @@ declare module '@deck.gl/core/lib/layer' {
 	import Component from '@deck.gl/core/lifecycle/component';
 	import { PickInfo } from '@deck.gl/core/lib/deck';
 	import * as hammerjs from 'hammerjs';
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 	export interface TransitionTiming {
 		duration?: number;
 		easing?: (t: number) => number;
@@ -964,7 +964,7 @@ declare module '@deck.gl/core/lib/layer' {
 		transitions?: { [attributeGetter: string]: TransitionTiming };
 		pickable?: boolean;
 		autoHighlight?: boolean;
-		highlightColor?: DeckGLColor;
+		highlightColor?: RGBAColor;
 		onClick?: LayerInputHandler;
 		onHover?: LayerInputHandler;
 		lightSettings?: LightSettings;
@@ -995,8 +995,8 @@ declare module '@deck.gl/core/lib/layer' {
 		use64bitPositions(): boolean;
 		onHover(info: any, pickingEvent: any): any;
 		onClick(info: any, pickingEvent: any): any;
-		nullPickingColor(): DeckGLColor;
-		encodePickingColor(i: any, target?: any[]): DeckGLColor;
+		nullPickingColor(): RGBAColor;
+		encodePickingColor(i: any, target?: any[]): RGBAColor;
 		decodePickingColor(color: any): number;
 		initializeState(): void;
 		getShaders(shaders: any): any;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2421,7 +2421,7 @@ declare module '@deck.gl/core' {
 	export { default as _SunLight } from '@deck.gl/core/effects/lighting/sun-light';
 	export { default as PostProcessEffect } from '@deck.gl/core/effects/post-process-effect';
 	export { default as _LayersPass } from '@deck.gl/core/passes/layers-pass';
-	export { default as Deck } from '@deck.gl/core/lib/deck';
+	export { default as Deck, DeckProps } from '@deck.gl/core/lib/deck';
 	export { default as LayerManager } from '@deck.gl/core/lib/layer-manager';
 	export { default as AttributeManager } from '@deck.gl/core/lib/attribute-manager';
 	export { default as Layer } from '@deck.gl/core/lib/layer';

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -952,7 +952,7 @@ declare module '@deck.gl/core/lib/layer' {
 		numberOfLights?: number
 	}
 	export interface LayerInputHandler {
-		(o: PickInfo, e: HammerInput): void;
+		(o: PickInfo<any>, e: HammerInput): void;
 	}
 	export type DataSet<D> = Iterable<D>;
 		// | AsyncIterable ToDo: Add AsyncIterable
@@ -2038,8 +2038,8 @@ declare module '@deck.gl/core/lib/deck' {
 		isDragging: boolean;
 	}
 
-	export interface PickInfo {
-		layer: Layer,
+	export interface PickInfo<D> {
+		layer: Layer<D>,
 		index: number;
 		object: object;
 		x: number;
@@ -2058,8 +2058,8 @@ declare module '@deck.gl/core/lib/deck' {
 		height: number | string;
 
 		// layer/view/controller settings
-		layers: Layer[];
-		layerFilter?: (x: { layer: Layer, viewport: Viewport, isPicking: boolean }) => boolean;
+		layers: Layer<any>[];
+		layerFilter?: (x: { layer: Layer<any>, viewport: Viewport, isPicking: boolean }) => boolean;
 		views?: View[];
 		initialViewState?: any;
 		viewState?: any;
@@ -2080,8 +2080,8 @@ declare module '@deck.gl/core/lib/deck' {
 		onViewStateChange?: (viewState: any) => any;
 		onBeforeRender?: () => any;
 		onAfterRender?: () => any;
-		onClick?: (info: PickInfo, pickedInfos: PickInfo[], e: MouseEvent) => any;
-		onHover?: (info: PickInfo, pickedInfos: PickInfo[], e: MouseEvent) => any;
+		onClick?: <D>(info: PickInfo<D>, pickedInfos: PickInfo<D>[], e: MouseEvent) => any;
+		onHover?: <D>(info: PickInfo<D>, pickedInfos: PickInfo<D>[], e: MouseEvent) => any;
 		onLoad?: () => any;
 
 		// Debug settings

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1070,7 +1070,7 @@ declare module '@deck.gl/core/lib/layer' {
 declare module '@deck.gl/core/lib/composite-layer' {
 	import Layer, { LayerProps } from '@deck.gl/core/lib/layer';
 	export interface CompositeLayerProps<D> extends LayerProps<D> {
-        _subLayerProps: Object,
+        _subLayerProps?: Object,
 	}
 	export default class CompositeLayer<D> extends Layer<D> {
 		constructor(props: CompositeLayerProps<D>);

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -104,7 +104,18 @@ declare module '@deck.gl/geo-layers/tile-layer/utils/tile-cache' {
 }
 declare module '@deck.gl/geo-layers/tile-layer/tile-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface TileLayerProps extends LayerProps {
+        maxZoom?: number | null;
+        minZoom?: number;
+        maxCacheSize?: number | null;
+        onViewportLoaded?: Function;
+        getTileData?: Function;
+        onTileError?: Function;
+        renderSubLayers?: Function;
+    }
 	export default class TileLayer extends CompositeLayer {
+    	constructor(props: TileLayerProps);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;
@@ -128,7 +139,16 @@ declare module '@deck.gl/geo-layers/tile-layer/tile-layer' {
 }
 declare module '@deck.gl/geo-layers/trips-layer/trips-layer' {
 	import { PathLayer } from '@deck.gl/layers';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { PathLayerProps } from "@deck.gl/layers/path-layer/path-layer";
+    export interface TripsLayerProps extends PathLayerProps, LayerProps {
+        currentTime?: number;
+        trailLength?: number;
+        getPath?: Function;
+        getTimestamps?: Function;
+    }
 	export default class TripsLayer extends PathLayer {
+		constructor(props: TripsLayerProps);
 		getShaders(): any;
 		initializeState(params: any): void;
 		draw(params: any): void;
@@ -222,7 +242,22 @@ declare module '@deck.gl/geo-layers/tile-3d-layer/get-frame-state' {
 }
 declare module '@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface Tile3DLayerProps extends LayerProps, CompositeLayerProps {
+        opacity?: number;
+        pointSize?: number;
+        data?: string;
+        _ionAssetId?: number | string;
+        _ionAccessToken?: string;
+        loadOptions?: Object;
+        getPointColor?: Function | Array<any>;
+        onTilesetLoad?: Function;
+        onTileLoad?: Function;
+        onTileUnload?: Function;
+        onTileLoadFail?: Function;
+    }
 	export default class Tile3DLayer extends CompositeLayer {
+    	constructor(props: Tile3DLayerProps);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -243,6 +243,7 @@ declare module '@deck.gl/geo-layers/tile-3d-layer/get-frame-state' {
 declare module '@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface Tile3DLayerProps extends LayerProps, CompositeLayerProps {
         opacity?: number;
         pointSize?: number;

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -242,7 +242,7 @@ declare module '@deck.gl/geo-layers/tile-3d-layer/get-frame-state' {
 declare module '@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     export interface Tile3DLayerProps<D> extends CompositeLayerProps<D> {
         opacity?: number;
         pointSize?: number;
@@ -250,7 +250,7 @@ declare module '@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer' {
         _ionAssetId?: number | string;
         _ionAccessToken?: string;
         loadOptions?: Object;
-        getPointColor?: ((tileData: Object) => DeckGLColor) | DeckGLColor;
+        getPointColor?: ((tileData: Object) => RGBAColor) | RGBAColor;
         onTilesetLoad?: (tileData: Object) => void;
         onTileLoad?: (tileHeader: Object) => void;
         onTileUnload?: (tileHeader: Object) => void;

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -6,7 +6,7 @@ declare module '@deck.gl/geo-layers/great-circle-layer/great-circle-vertex.glsl'
 }
 declare module '@deck.gl/geo-layers/great-circle-layer/great-circle-layer' {
 	import { ArcLayer } from '@deck.gl/layers';
-	export default class GreatCircleLayer extends ArcLayer {
+	export default class GreatCircleLayer<D> extends ArcLayer<D> {
 		getShaders(): any;
 	}
 
@@ -25,7 +25,7 @@ declare module '@deck.gl/geo-layers/s2-layer/s2-utils' {
 }
 declare module '@deck.gl/geo-layers/s2-layer/s2-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-	export default class S2Layer extends CompositeLayer {
+	export default class S2Layer<D> extends CompositeLayer<D> {
 		renderLayers(): any;
 	}
 
@@ -160,7 +160,7 @@ declare module '@deck.gl/geo-layers/trips-layer/trips-layer' {
 }
 declare module '@deck.gl/geo-layers/h3-layers/h3-cluster-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-	export default class H3ClusterLayer extends CompositeLayer {
+	export default class H3ClusterLayer<D> extends CompositeLayer<D> {
 		updateState({ props, oldProps, changeFlags }: {
 			props: any;
 			oldProps: any;
@@ -185,7 +185,7 @@ declare module '@deck.gl/geo-layers/h3-layers/h3-hexagon-layer' {
 	 * even when no corresponding hexagon is in the data set. You can check
 	 * index !== -1 to see if picking matches an actual object.
 	 */
-	export default class H3HexagonLayer extends CompositeLayer {
+	export default class H3HexagonLayer<D> extends CompositeLayer<D> {
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;
 		}): any;

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -105,17 +105,17 @@ declare module '@deck.gl/geo-layers/tile-layer/utils/tile-cache' {
 declare module '@deck.gl/geo-layers/tile-layer/tile-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface TileLayerProps extends LayerProps {
+    export interface TileLayerProps<D> extends LayerProps<D> {
         maxZoom?: number | null;
         minZoom?: number;
         maxCacheSize?: number | null;
-        onViewportLoaded?: Function;
+        onViewportLoaded?: (data: D[]) => void;
         getTileData?: Function;
         onTileError?: Function;
         renderSubLayers?: Function;
     }
-	export default class TileLayer extends CompositeLayer {
-    	constructor(props: TileLayerProps);
+	export default class TileLayer<D> extends CompositeLayer<D> {
+    	constructor(props: TileLayerProps<D>);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;
@@ -139,16 +139,15 @@ declare module '@deck.gl/geo-layers/tile-layer/tile-layer' {
 }
 declare module '@deck.gl/geo-layers/trips-layer/trips-layer' {
 	import { PathLayer } from '@deck.gl/layers';
-    import { LayerProps } from "@deck.gl/core/lib/layer";
-    import { PathLayerProps } from "@deck.gl/layers/path-layer/path-layer";
-    export interface TripsLayerProps extends PathLayerProps, LayerProps {
+    import { LayerPath, PathLayerProps } from "@deck.gl/layers/path-layer/path-layer";
+    export interface TripsLayerProps<D> extends PathLayerProps<D> {
         currentTime?: number;
         trailLength?: number;
-        getPath?: Function;
+        getPath?: (d: D) => LayerPath;
         getTimestamps?: Function;
     }
-	export default class TripsLayer extends PathLayer {
-		constructor(props: TripsLayerProps);
+	export default class TripsLayer<D> extends PathLayer<D> {
+		constructor(props: TripsLayerProps<D>);
 		getShaders(): any;
 		initializeState(params: any): void;
 		draw(params: any): void;
@@ -242,23 +241,23 @@ declare module '@deck.gl/geo-layers/tile-3d-layer/get-frame-state' {
 }
 declare module '@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-    import { LayerProps } from "@deck.gl/core/lib/layer";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-    export interface Tile3DLayerProps extends LayerProps, CompositeLayerProps {
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    export interface Tile3DLayerProps<D> extends CompositeLayerProps<D> {
         opacity?: number;
         pointSize?: number;
         data?: string;
         _ionAssetId?: number | string;
         _ionAccessToken?: string;
         loadOptions?: Object;
-        getPointColor?: Function | Array<any>;
-        onTilesetLoad?: Function;
-        onTileLoad?: Function;
-        onTileUnload?: Function;
-        onTileLoadFail?: Function;
+        getPointColor?: ((tileData: Object) => DeckGLColor) | DeckGLColor;
+        onTilesetLoad?: (tileData: Object) => void;
+        onTileLoad?: (tileHeader: Object) => void;
+        onTileUnload?: (tileHeader: Object) => void;
+        onTileLoadFail?: (tileHeader: Object, url: string, message: string) => void;
     }
-	export default class Tile3DLayer extends CompositeLayer {
-    	constructor(props: Tile3DLayerProps);
+	export default class Tile3DLayer<D> extends CompositeLayer<D> {
+    	constructor(props: Tile3DLayerProps<D>);
 		initializeState(): void;
 		shouldUpdateState({ changeFlags }: {
 			changeFlags: any;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -11,7 +11,7 @@ declare module '@deck.gl/layers/arc-layer/arc-layer-fragment.glsl' {
 }
 declare module '@deck.gl/layers/arc-layer/arc-layer' {
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     export interface ArcLayerProps<D> extends LayerProps<D> {
         widthUnits?: string;
         widthScale?: number;
@@ -19,8 +19,8 @@ declare module '@deck.gl/layers/arc-layer/arc-layer' {
         widthMaxPixels?: number;
         getSourcePosition?: (d: D) => [number, number];
         getTargetPosition?: (d: D) => [number, number];
-        getSourceColor?: ((d: D) => DeckGLColor) | DeckGLColor;
-        getTargetColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getSourceColor?: ((d: D) => RGBAColor) | RGBAColor;
+        getTargetColor?: ((d: D) => RGBAColor) | RGBAColor;
         getWidth?: ((d: D) => number) | number;
         getHeight?: ((d: D) => number) | number;
         getTilt?: ((d: D) => number) | number;
@@ -63,11 +63,11 @@ declare module '@deck.gl/layers/bitmap-layer/bitmap-layer' {
         bounds: [number, number, number, number]
 			| [[number, number], [number, number], [number, number], [number, number]];
         desaturate: number;
-        transparentColor: DeckGLColor;
+        transparentColor: RGBAColor;
         tintColor: [number, number, number];
     }
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 	export default class BitmapLayer<D> extends Layer<D> {
 		constructor(props: BitmapLayerProps<D>)
 		getShaders(): any;
@@ -151,7 +151,7 @@ declare module '@deck.gl/layers/icon-layer/icon-layer' {
 	import { LayerProps } from '@deck.gl/core/lib/layer';
 	import { Position } from '@deck.gl/core/utils/positions';
 	import Texture2D from '@luma.gl/webgl/classes/texture-2d';
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 
 	export interface IconDefinition {
 		x: number;
@@ -206,7 +206,7 @@ declare module '@deck.gl/layers/icon-layer/icon-layer' {
 		*  returns color of the icon in [r, g, b, a].
 		*  Only works on icons with mask: true.
 		*/
-		getColor?: ((x: D) => DeckGLColor) | DeckGLColor,
+		getColor?: ((x: D) => RGBAColor) | RGBAColor,
 
 		/*
 		*  returns icon size multiplier as a number
@@ -253,9 +253,9 @@ declare module '@deck.gl/layers/line-layer/line-layer-fragment.glsl' {
 declare module '@deck.gl/layers/line-layer/line-layer' {
 	import { Layer } from '@deck.gl/core';
 	import { LayerProps } from '@deck.gl/core/lib/layer';
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 	export interface LineLayerProps<D> extends LayerProps<D> {
-		getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+		getColor?: ((d: D) => RGBAColor) | RGBAColor;
 		getSourcePosition?: (d: D) => [number, number];
 		getTargetPosition?: (d: D) => [number, number];
 		getWidth?: ((d: D) => number) | number;
@@ -293,7 +293,7 @@ declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer-fragment.gls
 declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     import PhongMaterial from "@luma.gl/core/materials/phong-material";
     export interface PointCloudLayerProps<D> extends LayerProps<D> {
         sizeUnits?: string;
@@ -301,7 +301,7 @@ declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer' {
         material?: PhongMaterial;
         getPosition?: (d: D) => [number, number];
         getNormal?: ((d: D) => [number, number, number]) | [number, number, number];
-        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getColor?: ((d: D) => RGBAColor) | RGBAColor;
     }
 	export default class PointCloudLayer<D> extends Layer<D> {
     	constructor(props: PointCloudLayerProps<D>);
@@ -332,7 +332,7 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer-fragment.gls
 declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     export interface ScatterplotLayerProps<D> extends LayerProps<D> {
         radiusScale?: number;
         lineWidthUnits?: string;
@@ -345,10 +345,10 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
         lineWidthMaxPixels?: number;
         getPosition?: (d: D) => [number, number];
         getRadius?: ((d: D) => number) | number;
-        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
-        getFillColor?: ((d: D) => DeckGLColor) | DeckGLColor;
-        getLineColor?: ((d: D) => DeckGLColor) | DeckGLColor;
-        getLineWidth?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getColor?: ((d: D) => RGBAColor) | RGBAColor;
+        getFillColor?: ((d: D) => RGBAColor) | RGBAColor;
+        getLineColor?: ((d: D) => RGBAColor) | RGBAColor;
+        getLineWidth?: ((d: D) => RGBAColor) | RGBAColor;
     }
 	export default class ScatterplotLayer<D> extends Layer<D> {
     	constructor(props: ScatterplotLayerProps<D>);
@@ -388,7 +388,7 @@ declare module '@deck.gl/layers/column-layer/column-layer' {
 	import ColumnGeometry from '@deck.gl/layers/column-layer/column-geometry';
     import { LayerProps } from "@deck.gl/core/lib/layer";
     import PhongMaterial from "@luma.gl/core/materials/phong-material";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 	export interface ColumnLayerProps<D> extends LayerProps<D> {
         diskResolution?: number;
         radius?: number;
@@ -407,8 +407,8 @@ declare module '@deck.gl/layers/column-layer/column-layer' {
         lineWidthMaxPixels?: number;
         material?: PhongMaterial;
         getPosition?: (d: D) => [number, number];
-        getFillColor?: ((d: D) => DeckGLColor) | DeckGLColor;
-        getLineColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getFillColor?: ((d: D) => RGBAColor) | RGBAColor;
+        getLineColor?: ((d: D) => RGBAColor) | RGBAColor;
         getElevation?: ((d: D) => number) | number;
         getLineWidth?: ((d: D) => number) | number;
     }
@@ -441,7 +441,7 @@ declare module '@deck.gl/layers/column-layer/grid-cell-layer' {
 	import ColumnLayer from '@deck.gl/layers/column-layer/column-layer';
     import { LayerProps } from "@deck.gl/core/lib/layer";
     import PhongMaterial from "@luma.gl/core/materials/phong-material";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     export interface GridCellLayerProps<D> extends LayerProps<D> {
         cellSize?: number;
         coverage?: number;
@@ -449,7 +449,7 @@ declare module '@deck.gl/layers/column-layer/grid-cell-layer' {
         extruded?: boolean;
         material?: PhongMaterial;
         getPosition?: (d: D) => [number, number];
-        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getColor?: ((d: D) => RGBAColor) | RGBAColor;
         getElevation?: ((d: D) => number) | number;
     }
 	export default class GridCellLayer<D> extends ColumnLayer<D> {
@@ -492,7 +492,7 @@ declare module '@deck.gl/layers/path-layer/path-layer-fragment.glsl' {
 declare module '@deck.gl/layers/path-layer/path-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Uint8ClampedArray
 		| Float32Array | Float64Array;
     type LayerPath = ([number, number, number])[] | TypedArray
@@ -506,7 +506,7 @@ declare module '@deck.gl/layers/path-layer/path-layer' {
         miterLimit?: number;
         dashJustified?: boolean;
         getPath?: (d: D) => LayerPath;
-        getColor?: (d: D) => DeckGLColor | DeckGLColor;
+        getColor?: (d: D) => RGBAColor | RGBAColor;
         getWidth?: (path: LayerPath) => number | number;
         getDashArray?: (path: LayerPath) => [number, number] | [number, number];
     }
@@ -601,7 +601,7 @@ declare module '@deck.gl/layers/solid-polygon-layer/solid-polygon-layer' {
 	import { Material } from '@luma.gl/core';
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from '@deck.gl/core/lib/layer';
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 	export type Polygon = number[][] | number[][][];
 	export interface SolidPolygonLayerProps<D> extends LayerProps<D> {
 		filled?: boolean;
@@ -610,8 +610,8 @@ declare module '@deck.gl/layers/solid-polygon-layer/solid-polygon-layer' {
 		wireframe?: boolean;
 		elevationScale?: number;
 		getElevation?: ((x: D) => number) | number;
-		getFillColor?: ((x: D) => DeckGLColor) | DeckGLColor;
-		getLineColor?: ((x: D) => DeckGLColor) | DeckGLColor;
+		getFillColor?: ((x: D) => RGBAColor) | RGBAColor;
+		getLineColor?: ((x: D) => RGBAColor) | RGBAColor;
 		getPolygon?: (x: D) => Polygon;
 	}
 	export default class SolidPolygonLayer<D> extends Layer<D> {
@@ -654,15 +654,15 @@ declare module '@deck.gl/layers/polygon-layer/polygon-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
 	import { Polygon } from '@deck.gl/layers/solid-polygon-layer/solid-polygon-layer';
 	export { Polygon };
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
 	export interface PolygonLayerProps<D> extends CompositeLayerProps<D> {
 		data: D[];
 		extruded: boolean;
 		stroked: boolean;
 		getElevation?: ((x: D) => number) | number;
-		getFillColor?: ((x: D) => DeckGLColor) | DeckGLColor;
-		getLineColor?: ((x: D) => DeckGLColor) | DeckGLColor;
+		getFillColor?: ((x: D) => RGBAColor) | RGBAColor;
+		getLineColor?: ((x: D) => RGBAColor) | RGBAColor;
 		getLineWidth?: ((x: D) => number) | number;
 		getPolygon?: (x: D) => Polygon;
 	}
@@ -706,7 +706,7 @@ declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     import PhongMaterial from "@luma.gl/core/materials/phong-material";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     export interface GeoJsonLayerProps<D> extends CompositeLayerProps<D> {
         filled?: boolean;
         stroked?: boolean;
@@ -724,8 +724,8 @@ declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
         pointRadiusMaxPixels?: number;
         lineDashJustified?: boolean;
         material?: PhongMaterial;
-        getLineColor?:  ((d: D) => DeckGLColor) | DeckGLColor;
-        getFillColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getLineColor?:  ((d: D) => RGBAColor) | RGBAColor;
+        getFillColor?: ((d: D) => RGBAColor) | RGBAColor;
         getRadius?: ((d: D) => number) | number;
         getLineWidth?: ((d: D) => number) | number;
         getElevation?: ((d: D) => number) | number;
@@ -889,7 +889,7 @@ declare module '@deck.gl/layers/text-layer/font-atlas-manager' {
 declare module '@deck.gl/layers/text-layer/text-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
 	import { FontSettings } from '@deck.gl/layers/text-layer/font-atlas-manager';
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
 	export type TextAnchor = 'start' | 'middle' | 'end';
 	export type AlignmentBaseline = 'top' | 'center' | 'bottom';
@@ -899,7 +899,7 @@ declare module '@deck.gl/layers/text-layer/text-layer' {
 		fontSettings?: FontSettings;
 		fontWeight?: number | string;
 		fp64?: boolean;
-		getColor?: ((x: D) => DeckGLColor) | DeckGLColor;
+		getColor?: ((x: D) => RGBAColor) | RGBAColor;
 		getText?: (x: D) => string;
 		getPosition?: (x: D) => [number, number];
 		getSize?: ((x: D) => number) | number;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -11,22 +11,23 @@ declare module '@deck.gl/layers/arc-layer/arc-layer-fragment.glsl' {
 }
 declare module '@deck.gl/layers/arc-layer/arc-layer' {
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface ArcLayerProps extends LayerProps {
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    export interface ArcLayerProps<D> extends LayerProps<D> {
         widthUnits?: string;
         widthScale?: number;
         widthMinPixels?: number;
         widthMaxPixels?: number;
-        getSourcePosition?: Function;
-        getTargetPosition?: Function;
-        getSourceColor?: Function | Array<any>;
-        getTargetColor?: Function | Array<any>;
-        getWidth?: Function | number;
-        getHeight?: Function | number;
-        getTilt?: Function | number;
+        getSourcePosition?: (d: D) => [number, number];
+        getTargetPosition?: (d: D) => [number, number];
+        getSourceColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getTargetColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getWidth?: ((d: D) => number) | number;
+        getHeight?: ((d: D) => number) | number;
+        getTilt?: ((d: D) => number) | number;
     }
 	import { Layer } from '@deck.gl/core';
-	export default class ArcLayer extends Layer {
-		constructor(props: ArcLayerProps)
+	export default class ArcLayer<D> extends Layer<D> {
+		constructor(props: ArcLayerProps<D>)
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -57,16 +58,18 @@ declare module '@deck.gl/layers/bitmap-layer/bitmap-layer-fragment' {
 }
 declare module '@deck.gl/layers/bitmap-layer/bitmap-layer' {
 	import { Layer } from '@deck.gl/core';
-    export interface BitmapLayerProps extends LayerProps {
-        bitmap: any
-        bounds: Array<any>
-        desaturate: number
-        transparentColor: Array<any>
-        tintColor: Array<any>
+    export interface BitmapLayerProps<D> extends LayerProps<D> {
+        bitmap: any;
+        bounds: [number, number, number, number]
+			| [[number, number], [number, number], [number, number], [number, number]];
+        desaturate: number;
+        transparentColor: DeckGLColor;
+        tintColor: [number, number, number];
     }
     import { LayerProps } from "@deck.gl/core/lib/layer";
-	export default class BitmapLayer extends Layer {
-		constructor(props: BitmapLayerProps)
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+	export default class BitmapLayer<D> extends Layer<D> {
+		constructor(props: BitmapLayerProps<D>)
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -80,6 +83,11 @@ declare module '@deck.gl/layers/bitmap-layer/bitmap-layer' {
 		draw(opts: any): void;
 		loadTexture(image: any): void;
 	}
+
+}
+declare module '@deck.gl/layers/elevation' {
+    export type ElevationRange = [number, number];
+    export type ElevationDomain = [number, number];
 
 }
 declare module '@deck.gl/layers/icon-layer/icon-layer-vertex.glsl' {
@@ -141,9 +149,9 @@ declare module '@deck.gl/layers/icon-layer/icon-manager' {
 declare module '@deck.gl/layers/icon-layer/icon-layer' {
 	import { Layer } from '@deck.gl/core';
 	import { LayerProps } from '@deck.gl/core/lib/layer';
-	import { Color } from '@deck.gl/core/utils/color';
 	import { Position } from '@deck.gl/core/utils/positions';
 	import Texture2D from '@luma.gl/webgl/classes/texture-2d';
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 
 	export interface IconDefinition {
 		x: number;
@@ -175,23 +183,7 @@ declare module '@deck.gl/layers/icon-layer/icon-layer' {
 		[key: string]: IconDefinition;
 	}
 
-	export interface IconLayerDatum {
-		/*
-		*  icon name
-		*/
-		icon?: string;
-		/*
-		*  color of the icon in [r, g, b, a].
-		*/
-		color?: Color;
-		/*
-		*  anchor position of the icon, in [lng, lat, z]
-		*/
-		position?: Position;
-	}
-
-	export interface IconLayerProps {
-		data: IconLayerDatum[];
+	export interface IconLayerProps<D> extends LayerProps<D> {
 		/*
 		*  atlas image url or texture
 		*/
@@ -203,32 +195,32 @@ declare module '@deck.gl/layers/icon-layer/icon-layer' {
 		/*
 		*  returns anchor position of the icon, in [lng, lat, z]
 		*/
-		getPosition?: ((x: IconLayerDatum) => Position),
+		getPosition?: ((x: D) => Position),
 
 		/*
 		*  returns icon name as a string
 		*/
-		getIcon?: ((x: IconLayerDatum) => string) | string,
+		getIcon?: ((x: D) => string) | string,
 
 		/*
 		*  returns color of the icon in [r, g, b, a].
 		*  Only works on icons with mask: true.
 		*/
-		getColor?: ((x: IconLayerDatum) => Color) | Color,
+		getColor?: ((x: D) => DeckGLColor) | DeckGLColor,
 
 		/*
 		*  returns icon size multiplier as a number
 		*/
-		getSize?: ((x: IconLayerDatum) => number) | number,
+		getSize?: ((x: D) => number) | number,
 
 		/*
 		*  returns rotating angle (in degree) of the icon.
 		*/
-		getAngle?: ((x: IconLayerDatum) => number) | number,
+		getAngle?: ((x: D) => number) | number,
 	}
 
-	export default class IconLayer extends Layer {
-		constructor(...props: (LayerProps & IconLayerProps)[]);
+	export default class IconLayer<D> extends Layer<D> {
+		constructor(props: IconLayerProps<D>);
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
@@ -261,29 +253,24 @@ declare module '@deck.gl/layers/line-layer/line-layer-fragment.glsl' {
 declare module '@deck.gl/layers/line-layer/line-layer' {
 	import { Layer } from '@deck.gl/core';
 	import { LayerProps } from '@deck.gl/core/lib/layer';
-	import { Color } from '@deck.gl/core/utils/color';
-	export interface LineLayerDatum {
-		sourcePosition?: number[];
-		targetPosition?: number[];
-	}
-	export interface LineLayerProps {
-		data: LineLayerDatum[];
-		getColor?: ((o: LineLayerDatum) => Color) | Color;
-		getSourcePosition?: (o: LineLayerDatum) => number[];
-		getTargetPosition ?: (o: LineLayerDatum) => number[];
-		getWidth?: ((o: LineLayerDatum) => number) | number;
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+	export interface LineLayerProps<D> extends LayerProps<D> {
+		getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+		getSourcePosition?: (d: D) => [number, number];
+		getTargetPosition?: (d: D) => [number, number];
+		getWidth?: ((d: D) => number) | number;
 		widthMaxPixels?: number;
 		widthMinPixels?: number;
 		widthScale?: number;
 		widthUnits?: 'meters' | 'pixels';
 	}
-	export default class LineLayer extends Layer {
-		constructor(props: LayerProps & LineLayerProps);
+	export default class LineLayer<D> extends Layer<D> {
+		constructor(props: LineLayerProps<D>);
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
-			props: LayerProps & LineLayerProps;
-			oldProps: LayerProps & LineLayerProps;
+			props: LineLayerProps<D>;
+			oldProps: LineLayerProps<D>;
 			changeFlags: any;
 		}): void;
 		draw({ uniforms }: {
@@ -306,16 +293,18 @@ declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer-fragment.gls
 declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface PointCloudLayerProps extends LayerProps {
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import PhongMaterial from "@luma.gl/core/materials/phong-material";
+    export interface PointCloudLayerProps<D> extends LayerProps<D> {
         sizeUnits?: string;
         pointSize?: number;
-        material?: Object;
-        getPosition?: Function;
-        getNormal?: Function | Array<any>;
-        getColor?: Function | Array<any>;
+        material?: PhongMaterial;
+        getPosition?: (d: D) => [number, number];
+        getNormal?: ((d: D) => [number, number, number]) | [number, number, number];
+        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
     }
-	export default class PointCloudLayer extends Layer {
-    	constructor(props: PointCloudLayerProps);
+	export default class PointCloudLayer<D> extends Layer<D> {
+    	constructor(props: PointCloudLayerProps<D>);
 		getShaders(id: any): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -343,7 +332,8 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer-fragment.gls
 declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface ScatterplotLayerProps extends LayerProps {
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    export interface ScatterplotLayerProps<D> extends LayerProps<D> {
         radiusScale?: number;
         lineWidthUnits?: string;
         lineWidthScale?: number;
@@ -353,15 +343,15 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
         radiusMaxPixels?: number;
         lineWidthMinPixels?: number;
         lineWidthMaxPixels?: number;
-        getPosition?: Function;
-        getRadius?: Function | number;
-        getColor?: Function | Array<any>;
-        getFillColor?: Function | Array<any>;
-        getLineColor?: Function | Array<any>;
-        getLineWidth?: Function | Array<any>;
+        getPosition?: (d: D) => [number, number];
+        getRadius?: ((d: D) => number) | number;
+        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getFillColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getLineColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getLineWidth?: ((d: D) => DeckGLColor) | DeckGLColor;
     }
-	export default class ScatterplotLayer extends Layer {
-    	constructor(props: ScatterplotLayerProps);
+	export default class ScatterplotLayer<D> extends Layer<D> {
+    	constructor(props: ScatterplotLayerProps<D>);
 		getShaders(id: any): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -397,11 +387,13 @@ declare module '@deck.gl/layers/column-layer/column-layer' {
 	import { Layer } from '@deck.gl/core';
 	import ColumnGeometry from '@deck.gl/layers/column-layer/column-geometry';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-	export interface ColumnLayerProps extends LayerProps {
+    import PhongMaterial from "@luma.gl/core/materials/phong-material";
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+	export interface ColumnLayerProps<D> extends LayerProps<D> {
         diskResolution?: number;
         radius?: number;
         angle?: number;
-        vertices?: Array<any>;
+        vertices?: [number, number][];
         offset?: number;
         coverage?: number;
         elevationScale?: number;
@@ -414,15 +406,15 @@ declare module '@deck.gl/layers/column-layer/column-layer' {
         lineWidthScale?: boolean;
         lineWidthMinPixels?: number;
         lineWidthMaxPixels?: number;
-        material?: Object;
-        getPosition?: Function;
-        getFillColor?: Function | Array<any>;
-        getLineColor?: Function | Array<any>;
-        getElevation?: Function | number;
-        getLineWidth?: Function | number;
+        material?: PhongMaterial;
+        getPosition?: (d: D) => [number, number];
+        getFillColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getLineColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getElevation?: ((d: D) => number) | number;
+        getLineWidth?: ((d: D) => number) | number;
     }
-	export default class ColumnLayer extends Layer {
-		constructor(props: ColumnLayerProps);
+	export default class ColumnLayer<D> extends Layer<D> {
+		constructor(props: ColumnLayerProps<D>);
 		getShaders(): any;
 	    /**
 	     * DeckGL calls initializeState when GL context is available
@@ -449,18 +441,20 @@ declare module '@deck.gl/layers/column-layer/column-layer' {
 declare module '@deck.gl/layers/column-layer/grid-cell-layer' {
 	import ColumnLayer from '@deck.gl/layers/column-layer/column-layer';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface GridCellLayerProps extends LayerProps {
+    import PhongMaterial from "@luma.gl/core/materials/phong-material";
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    export interface GridCellLayerProps<D> extends LayerProps<D> {
         cellSize?: number;
         coverage?: number;
         elevationScale?: number;
         extruded?: boolean;
-        material?: Object;
-        getPosition?: Function;
-        getColor?: Function | Array<any>;
-        getElevation?: Function | number;
+        material?: PhongMaterial;
+        getPosition?: (d: D) => [number, number];
+        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getElevation?: ((d: D) => number) | number;
     }
-	export default class GridCellLayer extends ColumnLayer {
-    	constructor(props: GridCellLayerProps);
+	export default class GridCellLayer<D> extends ColumnLayer<D> {
+    	constructor(props: GridCellLayerProps<D>);
 		getGeometry(diskResolution: any): any;
 		draw({ uniforms }: {
 			uniforms: any;
@@ -499,7 +493,11 @@ declare module '@deck.gl/layers/path-layer/path-layer-fragment.glsl' {
 declare module '@deck.gl/layers/path-layer/path-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface PathLayerProps extends LayerProps {
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Uint8ClampedArray
+		| Float32Array | Float64Array;
+    type LayerPath = ([number, number, number])[] | TypedArray
+    export interface PathLayerProps<D> extends LayerProps<D> {
         widthUnits?: string;
         widthScale?: number;
         widthMinPixels?: number;
@@ -508,13 +506,13 @@ declare module '@deck.gl/layers/path-layer/path-layer' {
         billboard?: boolean;
         miterLimit?: number;
         dashJustified?: boolean;
-        getPath?: Function;
-        getColor?: Function | Array<any>;
-        getWidth?: Function | number;
-        getDashArray?: Function | Array<any>;
+        getPath?: (d: D) => LayerPath;
+        getColor?: (d: D) => DeckGLColor | DeckGLColor;
+        getWidth?: (path: LayerPath) => number | number;
+        getDashArray?: (path: LayerPath) => [number, number] | [number, number];
     }
-	export default class PathLayer extends Layer {
-    	constructor(props: PathLayerProps);
+	export default class PathLayer<D> extends Layer<D> {
+    	constructor(props: PathLayerProps<D>);
 		getShaders(): any;
 		initializeState(params?: any): void;
 		updateState({ oldProps, props, changeFlags }: {
@@ -602,27 +600,23 @@ declare module '@deck.gl/layers/solid-polygon-layer/solid-polygon-layer-fragment
 }
 declare module '@deck.gl/layers/solid-polygon-layer/solid-polygon-layer' {
 	import { Material } from '@luma.gl/core';
-	import { Color } from '@deck.gl/core/utils/color';
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from '@deck.gl/core/lib/layer';
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
 	export type Polygon = number[][] | number[][][];
-	export interface SolidPolygonLayerDatum {
-		polygon?: Polygon
-	}
-	export interface SolidPolygonLayerProps {
-		data: SolidPolygonLayerDatum[];
+	export interface SolidPolygonLayerProps<D> extends LayerProps<D> {
 		filled?: boolean;
 		extruded?: boolean;
 		material?: Material;
 		wireframe?: boolean;
 		elevationScale?: number;
-		getElevation?: ((x: SolidPolygonLayerDatum) => number) | number;
-		getFillColor?: ((x: SolidPolygonLayerDatum) => Color) | Color;
-		getLineColor?: ((x: SolidPolygonLayerDatum) => Color) | Color;
-		getPolygon?: (x: SolidPolygonLayerDatum) => Polygon;
+		getElevation?: ((x: D) => number) | number;
+		getFillColor?: ((x: D) => DeckGLColor) | DeckGLColor;
+		getLineColor?: ((x: D) => DeckGLColor) | DeckGLColor;
+		getPolygon?: (x: D) => Polygon;
 	}
-	import { LayerProps } from '@deck.gl/core/lib/layer';
-	export default class SolidPolygonLayer extends Layer {
-		constructor(props: LayerProps & SolidPolygonLayerProps);
+	export default class SolidPolygonLayer<D> extends Layer<D> {
+		constructor(props: SolidPolygonLayerProps<D>);
 		getShaders(vs: any): any;
 		initializeState(): void;
 		draw({ uniforms }: {
@@ -659,29 +653,22 @@ declare module '@deck.gl/layers/utils' {
 }
 declare module '@deck.gl/layers/polygon-layer/polygon-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-	import { Color } from '@deck.gl/core/utils/color';
 	import { Polygon } from '@deck.gl/layers/solid-polygon-layer/solid-polygon-layer';
 	export { Polygon };
-	export interface PolygonLayerDatum {
-		polygon?: Polygon;
-		elevation?: number;
-		fillColor?: number[];
-		lineColor?: number[];
-		lineWidth?: number;
-	}
-	export interface PolygonLayerProps {
-		data: PolygonLayerDatum[];
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
+	export interface PolygonLayerProps<D> extends CompositeLayerProps<D> {
+		data: D[];
 		extruded: boolean;
 		stroked: boolean;
-		getElevation?: ((x: PolygonLayerDatum) => number) | number;
-		getFillColor?: ((x: PolygonLayerDatum) => Color) | Color;
-		getLineColor?: ((x: PolygonLayerDatum) => Color) | Color;
-		getLineWidth?: ((x: PolygonLayerDatum) => number) | number;
-		getPolygon?: (x: PolygonLayerDatum) => Polygon;
+		getElevation?: ((x: D) => number) | number;
+		getFillColor?: ((x: D) => DeckGLColor) | DeckGLColor;
+		getLineColor?: ((x: D) => DeckGLColor) | DeckGLColor;
+		getLineWidth?: ((x: D) => number) | number;
+		getPolygon?: (x: D) => Polygon;
 	}
-	import { LayerProps } from '@deck.gl/core/lib/layer';
-	export default class PolygonLayer extends CompositeLayer {
-		constructor(props: LayerProps & PolygonLayerProps);
+	export default class PolygonLayer<D> extends CompositeLayer<D> {
+		constructor(props: PolygonLayerProps<D>);
 		initializeState(): void;
 		updateState({ oldProps, props, changeFlags }: {
 			oldProps: any;
@@ -718,9 +705,10 @@ declare module '@deck.gl/layers/geojson-layer/geojson' {
 }
 declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-    import { LayerProps } from "@deck.gl/core/lib/layer";
     import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-    export interface GeoJsonLayerProps extends LayerProps, CompositeLayerProps {
+    import PhongMaterial from "@luma.gl/core/materials/phong-material";
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    export interface GeoJsonLayerProps<D> extends CompositeLayerProps<D> {
         filled?: boolean;
         stroked?: boolean;
         extruded?: boolean;
@@ -736,16 +724,16 @@ declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
         pointRadiusMinPixels?: number;
         pointRadiusMaxPixels?: number;
         lineDashJustified?: boolean;
-        material?: Object;
-        getLineColor?: Function | Array<any>;
-        getFillColor?: Function | Array<any>;
-        getRadius?: Function | number;
-        getLineWidth?: Function | number;
-        getElevation?: Function | number;
-        getLineDashArray?: Function | Array<any>;
+        material?: PhongMaterial;
+        getLineColor?:  ((d: D) => DeckGLColor) | DeckGLColor;
+        getFillColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getRadius?: ((d: D) => number) | number;
+        getLineWidth?: ((d: D) => number) | number;
+        getElevation?: ((d: D) => number) | number;
+        getLineDashArray?: ((d: D) => [number, number]) | [number, number];
     }
-	export default class GeoJsonLayer extends CompositeLayer {
-    	constructor(props: GeoJsonLayerProps);
+	export default class GeoJsonLayer<D> extends CompositeLayer<D> {
+    	constructor(props: GeoJsonLayerProps<D>);
 		initializeState(): void;
 		updateState({ props, changeFlags }: {
 			props: any;
@@ -901,40 +889,29 @@ declare module '@deck.gl/layers/text-layer/font-atlas-manager' {
 }
 declare module '@deck.gl/layers/text-layer/text-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
-	import { LayerProps } from '@deck.gl/core/lib/layer';
-	import { Color } from '@deck.gl/core/utils/color';
 	import { FontSettings } from '@deck.gl/layers/text-layer/font-atlas-manager';
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
 	export type TextAnchor = 'start' | 'middle' | 'end';
 	export type AlignmentBaseline = 'top' | 'center' | 'bottom';
-	export interface TextLayerDatum {
-		text: string;
-		position: number[];
-		color?: Color;
-		size?: number;
-		angle?: number;
-		textAnchor?: TextAnchor;
-		alignmentBaseline?: AlignmentBaseline;
-		offset?: number[];
-		pixelOffset?: number[];
-	}
-	export interface TextLayerProps {
+	export interface TextLayerProps<D>  extends CompositeLayerProps<D> {
 		characterSet?: string | string[];
-		data: TextLayerDatum[];
 		fontFamily?: string;
 		fontSettings?: FontSettings;
 		fontWeight?: number | string;
 		fp64?: boolean;
-		getColor?: ((x: TextLayerDatum) => Color) | Color;
-		getText?: (x: TextLayerDatum) => string;
-		getPosition?: (x: TextLayerDatum) => number[];
-		getSize?: ((x: TextLayerDatum) => number) | number;
-		getAngle?: ((x: TextLayerDatum) => number) | number;
-		getTextAnchor?: (x: TextLayerDatum) => TextAnchor;
-		getAlignmentBaseline?: (x: TextLayerDatum) => AlignmentBaseline;
-		getPixelOffset?: (x: TextLayerDatum) => number[];
+		getColor?: ((x: D) => DeckGLColor) | DeckGLColor;
+		getText?: (x: D) => string;
+		getPosition?: (x: D) => [number, number];
+		getSize?: ((x: D) => number) | number;
+		getAngle?: ((x: D) => number) | number;
+		getTextAnchor?: (x: D) => TextAnchor;
+		getAlignmentBaseline?: (x: D) => AlignmentBaseline;
+		getPixelOffset?: (x: D) => number[];
 		sizeScale?: number;
 	}
-	export default class TextLayer extends CompositeLayer {
+	export default class TextLayer<D> extends CompositeLayer<D> {
+		constructor(props: TextLayerProps<D>);
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
 			props: any;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -398,7 +398,6 @@ declare module '@deck.gl/layers/column-layer/column-layer' {
         coverage?: number;
         elevationScale?: number;
         filled?: boolean;
-        filled?: boolean;
         stroked?: boolean;
         extruded?: boolean;
         wireframe?: boolean;
@@ -755,7 +754,7 @@ declare module '@deck.gl/layers/text-layer/multi-icon-layer/multi-icon-layer-fra
 }
 declare module '@deck.gl/layers/text-layer/multi-icon-layer/multi-icon-layer' {
 	import IconLayer from '@deck.gl/layers/icon-layer/icon-layer';
-	export default class MultiIconLayer extends IconLayer {
+	export default class MultiIconLayer<D> extends IconLayer<D> {
 		getShaders(): any;
 		initializeState(): void;
 		updateState(updateParams: any): void;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -719,6 +719,7 @@ declare module '@deck.gl/layers/geojson-layer/geojson' {
 declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
+    import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
     export interface GeoJsonLayerProps extends LayerProps, CompositeLayerProps {
         filled?: boolean;
         stroked?: boolean;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -10,8 +10,23 @@ declare module '@deck.gl/layers/arc-layer/arc-layer-fragment.glsl' {
 
 }
 declare module '@deck.gl/layers/arc-layer/arc-layer' {
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ArcLayerProps extends LayerProps {
+        widthUnits?: string;
+        widthScale?: number;
+        widthMinPixels?: number;
+        widthMaxPixels?: number;
+        getSourcePosition?: Function;
+        getTargetPosition?: Function;
+        getSourceColor?: Function | Array<any>;
+        getTargetColor?: Function | Array<any>;
+        getWidth?: Function | number;
+        getHeight?: Function | number;
+        getTilt?: Function | number;
+    }
 	import { Layer } from '@deck.gl/core';
 	export default class ArcLayer extends Layer {
+		constructor(props: ArcLayerProps)
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -42,7 +57,16 @@ declare module '@deck.gl/layers/bitmap-layer/bitmap-layer-fragment' {
 }
 declare module '@deck.gl/layers/bitmap-layer/bitmap-layer' {
 	import { Layer } from '@deck.gl/core';
+    export interface BitmapLayerProps extends LayerProps {
+        bitmap: any
+        bounds: Array<any>
+        desaturate: number
+        transparentColor: Array<any>
+        tintColor: Array<any>
+    }
+    import { LayerProps } from "@deck.gl/core/lib/layer";
 	export default class BitmapLayer extends Layer {
+		constructor(props: BitmapLayerProps)
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -281,7 +305,17 @@ declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer-fragment.gls
 }
 declare module '@deck.gl/layers/point-cloud-layer/point-cloud-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface PointCloudLayerProps extends LayerProps {
+        sizeUnits?: string;
+        pointSize?: number;
+        material?: Object;
+        getPosition?: Function;
+        getNormal?: Function | Array<any>;
+        getColor?: Function | Array<any>;
+    }
 	export default class PointCloudLayer extends Layer {
+    	constructor(props: PointCloudLayerProps);
 		getShaders(id: any): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -308,7 +342,26 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer-fragment.gls
 }
 declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ScatterplotLayerProps extends LayerProps {
+        radiusScale?: number;
+        lineWidthUnits?: string;
+        lineWidthScale?: number;
+        stroked?: boolean;
+        filled?: boolean;
+        radiusMinPixels?: number;
+        radiusMaxPixels?: number;
+        lineWidthMinPixels?: number;
+        lineWidthMaxPixels?: number;
+        getPosition?: Function;
+        getRadius?: Function | number;
+        getColor?: Function | Array<any>;
+        getFillColor?: Function | Array<any>;
+        getLineColor?: Function | Array<any>;
+        getLineWidth?: Function | Array<any>;
+    }
 	export default class ScatterplotLayer extends Layer {
+    	constructor(props: ScatterplotLayerProps);
 		getShaders(id: any): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -343,7 +396,33 @@ declare module '@deck.gl/layers/column-layer/column-layer-fragment.glsl' {
 declare module '@deck.gl/layers/column-layer/column-layer' {
 	import { Layer } from '@deck.gl/core';
 	import ColumnGeometry from '@deck.gl/layers/column-layer/column-geometry';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+	export interface ColumnLayerProps extends LayerProps {
+        diskResolution?: number;
+        radius?: number;
+        angle?: number;
+        vertices?: Array<any>;
+        offset?: number;
+        coverage?: number;
+        elevationScale?: number;
+        filled?: boolean;
+        filled?: boolean;
+        stroked?: boolean;
+        extruded?: boolean;
+        wireframe?: boolean;
+        lineWidthUnits?: string;
+        lineWidthScale?: boolean;
+        lineWidthMinPixels?: number;
+        lineWidthMaxPixels?: number;
+        material?: Object;
+        getPosition?: Function;
+        getFillColor?: Function | Array<any>;
+        getLineColor?: Function | Array<any>;
+        getElevation?: Function | number;
+        getLineWidth?: Function | number;
+    }
 	export default class ColumnLayer extends Layer {
+		constructor(props: ColumnLayerProps);
 		getShaders(): any;
 	    /**
 	     * DeckGL calls initializeState when GL context is available
@@ -369,7 +448,19 @@ declare module '@deck.gl/layers/column-layer/column-layer' {
 }
 declare module '@deck.gl/layers/column-layer/grid-cell-layer' {
 	import ColumnLayer from '@deck.gl/layers/column-layer/column-layer';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface GridCellLayerProps extends LayerProps {
+        cellSize?: number;
+        coverage?: number;
+        elevationScale?: number;
+        extruded?: boolean;
+        material?: Object;
+        getPosition?: Function;
+        getColor?: Function | Array<any>;
+        getElevation?: Function | number;
+    }
 	export default class GridCellLayer extends ColumnLayer {
+    	constructor(props: GridCellLayerProps);
 		getGeometry(diskResolution: any): any;
 		draw({ uniforms }: {
 			uniforms: any;
@@ -407,7 +498,23 @@ declare module '@deck.gl/layers/path-layer/path-layer-fragment.glsl' {
 }
 declare module '@deck.gl/layers/path-layer/path-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface PathLayerProps extends LayerProps {
+        widthUnits?: string;
+        widthScale?: number;
+        widthMinPixels?: number;
+        widthMaxPixels?: number;
+        rounded?: boolean;
+        billboard?: boolean;
+        miterLimit?: number;
+        dashJustified?: boolean;
+        getPath?: Function;
+        getColor?: Function | Array<any>;
+        getWidth?: Function | number;
+        getDashArray?: Function | Array<any>;
+    }
 	export default class PathLayer extends Layer {
+    	constructor(props: PathLayerProps);
 		getShaders(): any;
 		initializeState(params?: any): void;
 		updateState({ oldProps, props, changeFlags }: {
@@ -611,7 +718,33 @@ declare module '@deck.gl/layers/geojson-layer/geojson' {
 }
 declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
 	import { CompositeLayer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface GeoJsonLayerProps extends LayerProps, CompositeLayerProps {
+        filled?: boolean;
+        stroked?: boolean;
+        extruded?: boolean;
+        wireframe?: boolean;
+        lineWidthUnits?: string;
+        lineWidthScale?: number;
+        lineWidthMinPixels?: number;
+        lineWidthMaxPixels?: number;
+        lineJointRounded?: boolean;
+        lineMiterLimit?: number;
+        elevationScale?: number;
+        pointRadiusScale?: number;
+        pointRadiusMinPixels?: number;
+        pointRadiusMaxPixels?: number;
+        lineDashJustified?: boolean;
+        material?: Object;
+        getLineColor?: Function | Array<any>;
+        getFillColor?: Function | Array<any>;
+        getRadius?: Function | number;
+        getLineWidth?: Function | number;
+        getElevation?: Function | number;
+        getLineDashArray?: Function | Array<any>;
+    }
 	export default class GeoJsonLayer extends CompositeLayer {
+    	constructor(props: GeoJsonLayerProps);
 		initializeState(): void;
 		updateState({ props, changeFlags }: {
 			props: any;

--- a/deck.gl__mesh-layers/index.d.ts
+++ b/deck.gl__mesh-layers/index.d.ts
@@ -54,7 +54,22 @@ declare module '@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer-fragmen
 }
 declare module '@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface SimpleMeshLayerProps extends LayerProps {
+        mesh: any;
+        texture?: any;
+        sizeScale?: number;
+        wireframe?: boolean;
+        material?: Object;
+        getPosition?: Function;
+        getColor?: Function | Array<any>;
+        getOrientation?: Function | Array<any>;
+        getScale?: Function | Array<any>;
+        getTranslation?: Function | Array<any>;
+        getTransformMatrix?: Function | Array<any>;
+    }
 	export default class SimpleMeshLayer extends Layer {
+    	constructor(props: SimpleMeshLayerProps);
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -87,7 +102,24 @@ declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer-fragment.
 }
 declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer' {
 	import { Layer } from '@deck.gl/core';
+    import { LayerProps } from "@deck.gl/core/lib/layer";
+    export interface ScenegraphLayerProps extends LayerProps {
+        scenegraph: URL | Object | Promise<any>;
+        sizeScale?: number;
+        _animations?: Object;
+        getScene?: Function;
+        getAnimator?: Function;
+        _lighting?: string;
+        _imageBasedLightingEnvironment?: any
+        getPosition?: Function;
+        getColor?: Function | Array<any>;
+        getOrientation?: Function | Array<any>;
+        getScale?: Function | Array<any>;
+        getTranslation?: Function | Array<any>;
+        getTransformMatrix?: Function | Array<any>;
+    }
 	export default class ScenegraphLayer extends Layer {
+    	constructor(props: ScenegraphLayerProps);
 		initializeState(): void;
 		updateState(params: any): void;
 		finalizeState(): void;

--- a/deck.gl__mesh-layers/index.d.ts
+++ b/deck.gl__mesh-layers/index.d.ts
@@ -57,7 +57,7 @@ declare module '@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer' {
     import { LayerProps } from "@deck.gl/core/lib/layer";
     import Texture2D from "@luma.gl/webgl/classes/texture-2d";
     import PhongMaterial from "@luma.gl/core/materials/phong-material";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     export interface SimpleMesh {
         positions: Float32Array;
         normals: Float32Array;
@@ -71,7 +71,7 @@ declare module '@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer' {
         wireframe?: boolean;
         material?: PhongMaterial;
         getPosition?: (d: D) => [number, number];
-        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getColor?: ((d: D) => RGBAColor) | RGBAColor;
         getOrientation?: ((d: D) => Coordinates) | Coordinates;
         getScale?: ((d: D) => Coordinates) | Coordinates;
         getTranslation?: ((d: D) => Coordinates) | Coordinates;
@@ -113,7 +113,7 @@ declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
     import ScenegraphNode from "@luma.gl/core/scenegraph/nodes/scenegraph-node";
-    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     type Coordinates = [number, number, number]
     export interface ScenegraphLayerProps<D> extends LayerProps<D> {
         scenegraph: URL | ScenegraphNode | Promise<ScenegraphNode>;
@@ -124,7 +124,7 @@ declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer' {
         _lighting?: string;
         _imageBasedLightingEnvironment?: any
         getPosition?: Function;
-        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getColor?: ((d: D) => RGBAColor) | RGBAColor;
         getOrientation?: ((d: D) => Coordinates) | Coordinates;
         getScale?: ((d: D) => Coordinates) | Coordinates;
         getTranslation?: ((d: D) => Coordinates) | Coordinates;

--- a/deck.gl__mesh-layers/index.d.ts
+++ b/deck.gl__mesh-layers/index.d.ts
@@ -55,21 +55,30 @@ declare module '@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer-fragmen
 declare module '@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface SimpleMeshLayerProps extends LayerProps {
-        mesh: any;
-        texture?: any;
+    import Texture2D from "@luma.gl/webgl/classes/texture-2d";
+    import PhongMaterial from "@luma.gl/core/materials/phong-material";
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    export interface SimpleMesh {
+        positions: Float32Array;
+        normals: Float32Array;
+        texCoords: Float32Array;
+	}
+	type Coordinates = [number, number, number]
+    export interface SimpleMeshLayerProps<D> extends LayerProps<D> {
+        mesh: SimpleMesh;
+        texture?: Texture2D | HTMLImageElement | string;
         sizeScale?: number;
         wireframe?: boolean;
-        material?: Object;
-        getPosition?: Function;
-        getColor?: Function | Array<any>;
-        getOrientation?: Function | Array<any>;
-        getScale?: Function | Array<any>;
-        getTranslation?: Function | Array<any>;
-        getTransformMatrix?: Function | Array<any>;
+        material?: PhongMaterial;
+        getPosition?: (d: D) => [number, number];
+        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getOrientation?: ((d: D) => Coordinates) | Coordinates;
+        getScale?: ((d: D) => Coordinates) | Coordinates;
+        getTranslation?: ((d: D) => Coordinates) | Coordinates;
+        getTransformMatrix?: ((d: D) => number[][]) | number[][];
     }
-	export default class SimpleMeshLayer extends Layer {
-    	constructor(props: SimpleMeshLayerProps);
+	export default class SimpleMeshLayer<D> extends Layer<D> {
+    	constructor(props: SimpleMeshLayerProps<D>);
 		getShaders(): any;
 		initializeState(): void;
 		updateState({ props, oldProps, changeFlags }: {
@@ -103,8 +112,11 @@ declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer-fragment.
 declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer' {
 	import { Layer } from '@deck.gl/core';
     import { LayerProps } from "@deck.gl/core/lib/layer";
-    export interface ScenegraphLayerProps extends LayerProps {
-        scenegraph: URL | Object | Promise<any>;
+    import ScenegraphNode from "@luma.gl/core/scenegraph/nodes/scenegraph-node";
+    import { DeckGLColor } from "@deck.gl/aggregation-layers/utils/color-utils";
+    type Coordinates = [number, number, number]
+    export interface ScenegraphLayerProps<D> extends LayerProps<D> {
+        scenegraph: URL | ScenegraphNode | Promise<ScenegraphNode>;
         sizeScale?: number;
         _animations?: Object;
         getScene?: Function;
@@ -112,14 +124,14 @@ declare module '@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer' {
         _lighting?: string;
         _imageBasedLightingEnvironment?: any
         getPosition?: Function;
-        getColor?: Function | Array<any>;
-        getOrientation?: Function | Array<any>;
-        getScale?: Function | Array<any>;
-        getTranslation?: Function | Array<any>;
-        getTransformMatrix?: Function | Array<any>;
+        getColor?: ((d: D) => DeckGLColor) | DeckGLColor;
+        getOrientation?: ((d: D) => Coordinates) | Coordinates;
+        getScale?: ((d: D) => Coordinates) | Coordinates;
+        getTranslation?: ((d: D) => Coordinates) | Coordinates;
+        getTransformMatrix?: ((d: D) => number[][]) | number[][];
     }
-	export default class ScenegraphLayer extends Layer {
-    	constructor(props: ScenegraphLayerProps);
+	export default class ScenegraphLayer<D> extends Layer<D> {
+    	constructor(props: ScenegraphLayerProps<D>);
 		initializeState(): void;
 		updateState(params: any): void;
 		finalizeState(): void;

--- a/test/@deck.gl/core.d.ts
+++ b/test/@deck.gl/core.d.ts
@@ -1,3 +1,4 @@
 /// <reference path="../../deck.gl__core/index.d.ts" />
 
 import { AmbientLight, AttributeManager } from '@deck.gl/core';
+import { DeckProps } from "@deck.gl/core/lib/deck";


### PR DESCRIPTION
That main two changes are to genericise the "Data" type so that it's passed through all the various layer types: `PathLayer`..., `CompositeLayer` and the base layer `Layer`

I also started to tidy up the implementation of colours, not noticing that you already had `Color` defined. I'm happy to switch back to your name but given it's a bit of a non-standard colour representation, and `Color` is very overloaded already, I decided to go with `DeckGLColor`.

I might be wrong but based on the [deck.gl docs](https://deck.gl/#/documentation/deckgl-api-reference/layers/layer?section=data-iterable-string-promise-asynciterable-object-optional-) there appeared to be a couple of incorrect typings for the `data` prop. I removed these in favour of keeping the data elements generic. As I believe is the correct handling, based on the docs. Happy to discuss this further.

I've got my own project currently depending in this branch and it's working well for me.