### PR TITLE
changing getColorValue argument type from D to D[]

### DIFF
--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -549,7 +549,7 @@ declare module '@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer' {
         elevationLowerPercentile?: number;
         material?: Object;
         getPosition?: (d: D) => [number, number];
-        getColorValue?: (d: D) => any;
+        getColorValue?: (d: D[]) => any;
         getColorWeight?: (d: D) => any;
         colorAggregation?: string;
         getElevationValue?: (d: D) => any;


### PR DESCRIPTION
The getColorValue functions argument type was wrongly a single value instead of an Array, I have changed it, so now it compiles with proper functionality.
Thanks for creating this type definition!