### PR TITLE
V8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,22 @@ These will automatically appear in your projects `node_modules/@types` folder, t
 | 6.x.x           | 2.x.x                  |
 | 7.x.x           | 3.x.x                  |
 | 8.x.x           | 4.x.x                  |
+
+## Known issues
+
+These typings are now v4 which targets deck.gl v8. The following issues are changes to v8 from deck.gl v7 which have not been added to these typings:
+
+- [ ] [It is now possible to replace a layer's accessors with binary data attributes.](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#better-binary-data-support)
+- [ ] [GPU filtering for layers](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#gpu-data-filter-in-aggregation-layers) - Adds a [getFilterValue](https://github.com/uber/deck.gl/blob/master/docs/api-reference/extensions/data-filter-extension.md#getfiltervalue-function) to some layers.
+- [ ] [Optional specifying the _framebuffer prop of Deck.](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#other-new-features-and-improvements)
+- [ ] [Pick a 3d surface point in the scene](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#other-new-features-and-improvements) by passing unproject3D: true to deck.pickObject or deck.pickMultipleObjects.
+- [ ] ArcLayer supports drawing arcs between two 3D positions
+- [ ] TextLayer adds a new prop backgroundColor
+- [ ] TextLayer adds maxWidth and wordBreak props to support text wrapping
+- [ ] ScenegraphLayer adds props sizeMinPixels and sizeMaxPixels.
+- [ ] 64-bit positions are now 3D instead of 2D
+- [ ] FirstPersonView now supports pitch
+- [ ] FlyToInterpolator now supports duration: 'auto'.
+
+## 🙏
+Thanks to the community of contributors for adding many typings over the last few months. Please feel free to continue fixes for the above or any other issues. 🥂

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ These will automatically appear in your projects `node_modules/@types` folder, t
 | 5.x.x           | 1.x.x                  |
 | 6.x.x           | 2.x.x                  |
 | 7.x.x           | 3.x.x                  |
+| 8.x.x           | 4.x.x                  |

--- a/deck.gl__extensions/index.d.ts
+++ b/deck.gl__extensions/index.d.ts
@@ -88,9 +88,24 @@ declare module '@deck.gl/extensions/fp64/fp64' {
 	}
 
 }
+declare module '@deck.gl/extensions/path-style/path-style' {
+	import { LayerExtension } from '@deck.gl/core';
+	export default class PathStyleExtension extends LayerExtension {
+		constructor({ dash, offset }?: {
+			dash?: boolean;
+			offset?: boolean;
+		});
+		isEnabled(layer: any): any;
+		getShaders(extension: any): {};
+		initializeState(context: any, extension: any): void;
+		updateState(params: any, extension: any): void;
+	}
+
+}
 declare module '@deck.gl/extensions' {
 	export { default as BrushingExtension } from '@deck.gl/extensions/brushing/brushing';
 	export { default as DataFilterExtension } from '@deck.gl/extensions/data-filter/data-filter';
 	export { default as Fp64Extension } from '@deck.gl/extensions/fp64/fp64';
-
+	export { default as PathStyleExtension } from '@deck.gl/extensions/path-style/path-style';
+	
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danmarshall/deckgl-typings",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "description": "TypeScript declaration files for deck.gl",
   "types": "deck.gl/index.d.ts",
   "scripts": {


### PR DESCRIPTION
It seems there aren't any breaking changes in v8, from [the docs](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#deckgl-v80) the update is performance, and new functionality. 🙏

Here's what needs to be added in the typings:

- [ ] [It is now possible to replace a layer's accessors with binary data attributes.](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#better-binary-data-support)
- [ ] [GPU filtering for layers](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#gpu-data-filter-in-aggregation-layers) - Adds a [getFilterValue](https://github.com/uber/deck.gl/blob/master/docs/api-reference/extensions/data-filter-extension.md#getfiltervalue-function) to some layers.
- [ ] [Optional specifying the _framebuffer prop of Deck.](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#other-new-features-and-improvements)
- [ ] [Pick a 3d surface point in the scene](https://github.com/uber/deck.gl/blob/master/docs/whats-new.md#other-new-features-and-improvements) by passing unproject3D: true to deck.pickObject or deck.pickMultipleObjects.
- [ ] ArcLayer supports drawing arcs between two 3D positions
- [ ] TextLayer adds a new prop backgroundColor
- [ ] TextLayer adds maxWidth and wordBreak props to support text wrapping
- [ ] ScenegraphLayer adds props sizeMinPixels and sizeMaxPixels.
- [ ] 64-bit positions are now 3D instead of 2D
- [ ] FirstPersonView now supports pitch
- [ ] FlyToInterpolator now supports duration: 'auto'.

Fixes #62 

