### PR TITLE
Add ContextProvider to props for React component

### DIFF
--- a/deck.gl__react/index.d.ts
+++ b/deck.gl__react/index.d.ts
@@ -6,8 +6,11 @@ declare module '@deck.gl/react/utils/inherits-from' {
 declare module '@deck.gl/react/deckgl' {
 	import { DeckProps } from '@deck.gl/core/lib/deck';
 	import * as React from 'react';
-	export default class DeckGL extends React.Component<DeckProps, {}> {
-		constructor(props: DeckProps);
+	type ReactDeckProps = DeckProps & {
+		ContextProvider: React.Provider<any>;
+	}
+	export default class DeckGL extends React.Component<ReactDeckProps, {}> {
+		constructor(props: ReactDeckProps);
 		componentDidMount(): void;
 		shouldComponentUpdate(nextProps: any): boolean;
 		componentDidUpdate(): void;


### PR DESCRIPTION
As seen in [the docs](https://deck.gl/#/documentation/submodule-api-reference/deckgl-react/deckgl). I used `any` for the type of the provider because correctly reflecting the provider type would require several more imports, and there's not much risk of screwing up and passing the wrong thing into this field.