### PR TITLE
Allow 2-dimentional coordinates in a type LayerPath

### DIFF
--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -495,7 +495,7 @@ declare module '@deck.gl/layers/path-layer/path-layer' {
     import { RGBAColor } from "@deck.gl/aggregation-layers/utils/color-utils";
     type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Uint8ClampedArray
 		| Float32Array | Float64Array;
-    type LayerPath = ([number, number, number])[] | TypedArray
+    type LayerPath = ([number, number])[] |([number, number, number])[] | TypedArray
     export interface PathLayerProps<D> extends LayerProps<D> {
         widthUnits?: string;
         widthScale?: number;


### PR DESCRIPTION
**TL;DR** This PR allows 2D coordinates (i.e., without altitude) in a type `LayerPath`.


This TypeScript code 

```typescript
import { PathLayer } from '@deck.gl/layers';

interface Path {
  path: [number, number][],
  name: string,
  color: [number, number, number]
}

// Taken from PathLayer API documentation:
// https://deck.gl/#/documentation/deckgl-api-reference/layers/path-layer
const DATA: Path[] = [{
  path: [[-122.4, 37.7], [-122.5, 37.8], [-122.6, 37.85]],
  name: 'Richmond - Millbrae',
  color: [255, 0, 0]
}]

const pathlayer = new PathLayer({
  data: DATA,
  getPath: d => d.path,
})
```

yields the following error:

```typescript
example.ts:19:3 - error TS2322: Type '(d: Data) => [number, number][]' is not assignable to type '(d: Data) => LayerPath'.
  Type '[number, number][]' is not assignable to type 'LayerPath'.
    Type '[number, number][]' is not assignable to type '[number, number, number][]'.
      Property '2' is missing in type '[number, number]' but required in type '[number, number, number]'.
```

deck.gl documentation says a path can be compatible with the GeoJSON LineString spec:

> A path can be one of the following formats:
>
> - An array of points (`[x, y, z]`). Compatible with the GeoJSON [LineString](https://tools.ietf.org/html/rfc7946#section-3.1.4) specification.

and the definitions of LineString and position are as follows:

> For type "LineString", the "coordinates" member is an array of two or more positions.

> A position is an array of numbers.  There MUST be two or more elements.  The first two elements are longitude and latitude, or easting and northing, precisely in that order and using decimal numbers.  Altitude or elevation MAY be included as an optional third element.
>
> Implementations SHOULD NOT extend positions beyond three elements because the semantics of extra elements are unspecified and ambiguous.  Historically, some implementations have used a fourth element to carry a linear referencing measure (sometimes denoted as "M") or a numerical timestamp, but in most situations a parser will not be able to properly interpret these values.  The interpretation and meaning of additional elements is beyond the scope of this specification, and additional elements MAY be ignored by parsers.

So, I suppose `[number, number][]` should be assignable to `LayerPath` and changed the type definition accordingly.

I am not sure if the position spec encourages or discourages me to make `[number, number, number, number, ...number[]][]` assignable to `LayerPath`, but I didn't. We want to be strict in TypeScript, don't we?