### PR TITLE
Add missing definitions for LayerProps

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -959,15 +959,26 @@ declare module '@deck.gl/core/lib/layer' {
 	// | { length: number } Todo: Support non-iterable objects, see deck.gl docs: /docs/developer-guide/using-layers.md#accessors
 	export interface LayerProps<D> {
 		coordinateSystem?: number;
+		coordinateOrigin?: [number, number];
+		wrapLongitude?: boolean;
 		id?: string;
 		data?: DataSet<D> | Promise<DataSet<D>> | string;
+		visible?: boolean;
+		opacity?: number;
 		transitions?: { [attributeGetter: string]: TransitionTiming };
 		pickable?: boolean;
 		autoHighlight?: boolean;
 		highlightColor?: RGBAColor;
+		highlightedObjectIndex?: number;
 		onClick?: LayerInputHandler;
 		onHover?: LayerInputHandler;
+		onDragStart?: LayerInputHandler;
+		onDrag?: LayerInputHandler;
+		onDragEnd?: LayerInputHandler;
 		lightSettings?: LightSettings;
+		positionFormat?: 'XYZ' | 'XY';
+		colorFormat?: 'RGBA' | 'RGB';
+		numInstances?: number;
 	}
 	export default class Layer<D> extends Component {
 		constructor(props: LayerProps<D>);


### PR DESCRIPTION
While converting my React app to TypeScript, the compiler claimed `Object literal may only specify known properties, and 'opacity' does not exist in type 'TripsLayerProps<Trip>'`. So I added `opacity` definition to the underlying `LayerProps`.

Besides `opacity`, I also added some definitions for properties listed in [the documentation](https://deck.gl/#/documentation/deckgl-api-reference/layers/layer?section=properties). I didn't add definitions for unfamiliar properties, but I hope this PR brings a bit better coverage.