### PR TITLE
ScatterplotLayerProps getLineWidth type fixed (RGBAColor -> number)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ typings/
 
 # ignore for now
 package-lock.json
+yarn.lock

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -348,7 +348,7 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
         getColor?: ((d: D) => RGBAColor) | RGBAColor;
         getFillColor?: ((d: D) => RGBAColor) | RGBAColor;
         getLineColor?: ((d: D) => RGBAColor) | RGBAColor;
-        getLineWidth?: ((d: D) => RGBAColor) | RGBAColor;
+        getLineWidth?: ((d: D) => number) | number;
     }
 	export default class ScatterplotLayer<D> extends Layer<D> {
     	constructor(props: ScatterplotLayerProps<D>);


### PR DESCRIPTION
Fixes #74 

- Fixed type of `getLineWidth` in `ScatterplotLayerProps`
- Added yarn.lock to gitignore
- Tests passed