### PR TITLE
Expose _Cameralight, reinstate React DeckProps

### DIFF
--- a/deck.gl/index.d.ts
+++ b/deck.gl/index.d.ts
@@ -8,6 +8,7 @@
 
 declare module "deck.gl" {
   export {
+    _CameraLight,
     COORDINATE_SYSTEM,
     Deck,
     Layer,

--- a/deck.gl__react/index.d.ts
+++ b/deck.gl__react/index.d.ts
@@ -59,9 +59,10 @@ declare module "@deck.gl/react/utils/extract-styles" {
 	};
 }
 declare module "@deck.gl/react/deckgl" {
+	import { DeckProps } from '@deck.gl/core/lib/deck';
 	import { ReactElement } from "react";
 	export default class DeckGL extends React.Component {
-		constructor(props: any);
+		constructor(props: DeckProps);
 		componentDidMount(): void;
 		shouldComponentUpdate(nextProps: any): boolean;
 		componentDidUpdate(): void;


### PR DESCRIPTION
Fixes #85 