### PR TITLE
Add canvas to DeckProps

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2284,6 +2284,7 @@ declare module "@deck.gl/core/lib/deck" {
 		//Configuration Properties
 		id?: string;
 		style?: {};
+		canvas?: HTMLCanvasElement;
 		touchAction?: string;
 		pickingRadius?: number;
 		getTooltip?: <D>(


### PR DESCRIPTION
Deck class has a canvas prop but it was missing. This PR adds support for it.