### PR TITLE
Add public properties of Viewport.

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1309,6 +1309,7 @@ declare module "@deck.gl/core/lib/composite-layer" {
 	}
 }
 declare module "@deck.gl/core/viewports/viewport" {
+	import { Position } from "@deck.gl/core/utils/positions";
 	export default class Viewport {
 		/**
 		 * @classdesc
@@ -1318,6 +1319,15 @@ declare module "@deck.gl/core/viewports/viewport" {
 		 * A new viewport instance should be created if any parameters have changed.
 		 */
 		constructor(opts?: {});
+		id?: string;
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+		isGeospatial: boolean;
+		zoom: number;
+		scale: number;
+		position: Position;
 		get metersPerPixel(): number;
 		get projectionMode(): number;
 		equals(viewport: any): any;


### PR DESCRIPTION
Viewport has a number of public (not prefixed with _) properties and it is convenient to be able to access them. Without this I get errors about accessing non-existing properties.