### PR TITLE
Fix layer props

### DIFF
--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -6,7 +6,7 @@ declare module "@deck.gl/aggregation-layers/aggregation-layer" {
 	import { CompositeLayer } from "@deck.gl/core";
 	import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
 	export interface AggregationLayerProps<D> extends CompositeLayerProps<D> { }
-	export default class AggregationLayer<D> extends CompositeLayer<D> {
+	export default class AggregationLayer<D, P extends AggregationLayerProps<D> = AggregationLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: AggregationLayerProps<D>);
 		initializeState(dimensions: any): void;
 		updateState(opts: any): void;
@@ -306,7 +306,7 @@ declare module "@deck.gl/aggregation-layers/grid-aggregation-layer" {
 	} from "@deck.gl/aggregation-layers/aggregation-layer";
 	export interface GridAggregationLayerProps<D>
 		extends AggregationLayerProps<D> { }
-	export default class GridAggregationLayer<D> extends AggregationLayer<D> {
+	export default class GridAggregationLayer<D, P extends GridAggregationLayerProps<D> = GridAggregationLayerProps<D>> extends AggregationLayer<D, P> {
 		constructor(props: GridAggregationLayerProps<D>);
 		initializeState({ dimensions }: { dimensions: any }): void;
 		updateState(opts: any): void;
@@ -400,7 +400,7 @@ declare module "@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer"
 		getPosition?: (d: D) => Position;
 		getWeight?: (d: D) => number;
 	}
-	export default class ScreenGridLayer<D> extends GridAggregationLayer<D> {
+	export default class ScreenGridLayer<D, P extends ScreenGridLayerProps<D> = ScreenGridLayerProps<D>> extends GridAggregationLayer<D, P> {
 		constructor(props: ScreenGridLayerProps<D>);
 		initializeState(params: any): void;
 		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
@@ -611,7 +611,7 @@ declare module "@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer" {
 		onSetColorDomain?: () => void;
 		onSetElevationDomain?: () => void;
 	}
-	export default class CPUGridLayer<D> extends AggregationLayer<D> {
+	export default class CPUGridLayer<D, P extends CPUGridLayerProps<D> = CPUGridLayerProps<D>> extends AggregationLayer<D, P> {
 		constructor(props: CPUGridLayerProps<D>);
 		initializeState(params: any): void;
 		updateState(opts: any): void;
@@ -692,7 +692,7 @@ declare module "@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer" {
 		onSetColorDomain?: Function;
 		onSetElevationDomain?: Function;
 	}
-	export default class HexagonLayer<D> extends AggregationLayer<D> {
+	export default class HexagonLayer<D, P extends HexagonLayerProps<D> = HexagonLayerProps<D>> extends AggregationLayer<D, P> {
 		constructor(props: HexagonLayerProps<D>);
 		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
 		initializeState(params: any): void;
@@ -792,7 +792,7 @@ declare module "@deck.gl/aggregation-layers/contour-layer/contour-layer" {
 		getPosition?: (d: D) => Position;
 		getWeight?: (d: D) => number;
 	}
-	export default class ContourLayer<D> extends GridAggregationLayer<D> {
+	export default class ContourLayer<D, P extends ContourLayerProps<D> = ContourLayerProps<D>> extends GridAggregationLayer<D, P> {
 		constructor(props: ContourLayerProps<D>);
 		initializeState(params: any): void;
 		updateState(opts: any): void;
@@ -878,7 +878,7 @@ declare module "@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer" {
 		getElevationWeight?: (d: D) => number;
 		elevationAggregation?: AggregationOperation;
 	}
-	export default class GPUGridLayer<D> extends GridAggregationLayer<D> {
+	export default class GPUGridLayer<D, P extends GPUGridLayerProps<D> = GPUGridLayerProps<D>> extends GridAggregationLayer<D, P> {
 		constructor(props: GPUGridLayerProps<D>);
 		initializeState(params: any): void;
 		updateState(opts: any): void;
@@ -927,7 +927,7 @@ declare module "@deck.gl/aggregation-layers/grid-layer/grid-layer" {
 		onSetColorDomain?: () => void;
 		onSetElevationDomain?: () => void;
 	}
-	export default class GridLayer<D> extends CompositeLayer<D> {
+	export default class GridLayer<D, P extends GridLayerProps<D> = GridLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: GridLayerProps<D>);
 		initializeState(params: any): void;
 		updateState({
@@ -1015,7 +1015,7 @@ declare module "@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer" {
 		getPosition?: (d: D) => Position;
 		getWeight?: (d: D) => number;
 	}
-	export default class HeatmapLayer<D> extends AggregationLayer<D> {
+	export default class HeatmapLayer<D, P extends HeatmapLayerProps<D> = HeatmapLayerProps<D>> extends AggregationLayer<D, P> {
 		constructor(props: HeatmapLayerProps<D>);
 		initializeState(params: any): void;
 		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -42,7 +42,7 @@ declare module "@deck.gl/geo-layers/s2-layer/s2-layer" {
 	export interface S2LayerProps<D> extends CompositeLayerProps<D> {
 		getS2Token: (d:D)=> any;
 	}	
-	export default class S2Layer<D> extends CompositeLayer<D> {
+	export default class S2Layer<D, P extends S2LayerProps<D> = S2LayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: S2LayerProps<D>);
 		renderLayers(): any;
 	}
@@ -242,7 +242,7 @@ declare module "@deck.gl/geo-layers/tile-layer/tile-layer" {
 		onTileLoad?: (tile: D) => void;
 		onTileError?: (error: Error) => void;
 	}
-	export default class TileLayer<D> extends CompositeLayer<D> {
+	export default class TileLayer<D, P extends TileLayerProps<D> = TileLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: TileLayerProps<D>);
 		initializeState(params: any): void;
 		get isLoaded(): any;
@@ -289,7 +289,7 @@ declare module "@deck.gl/geo-layers/trips-layer/trips-layer" {
 				target:number[]
 			}) => number[];
 	}
-	export default class TripsLayer<D> extends PathLayer<D> {
+	export default class TripsLayer<D, P extends TripsLayerProps<D> = TripsLayerProps<D>> extends PathLayer<D, P> {
 		constructor(props: TripsLayerProps<D>);
 		getShaders(): any;
 		initializeState(params?: any): void;
@@ -302,7 +302,7 @@ declare module "@deck.gl/geo-layers/h3-layers/h3-cluster-layer" {
 	export interface H3ClusterLayerProps<D> extends PolygonLayerProps<D> { 
 		getHexagons?: (d: D) => string[];
 	}
-	export default class H3ClusterLayer<D> extends CompositeLayer<D> {
+	export default class H3ClusterLayer<D, P extends H3ClusterLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: H3ClusterLayerProps<D>);
 		updateState({
 			props,
@@ -338,7 +338,7 @@ declare module "@deck.gl/geo-layers/h3-layers/h3-hexagon-layer" {
 	 * even when no corresponding hexagon is in the data set. You can check
 	 * index !== -1 to see if picking matches an actual object.
 	 */
-	export default class H3HexagonLayer<D> extends CompositeLayer<D> {
+	export default class H3HexagonLayer<D, P extends H3HexagonLayerProps<D> = H3HexagonLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: H3HexagonLayerProps<D>);
 		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
 		updateState({
@@ -403,7 +403,7 @@ declare module "@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer" {
 		onTileUnload?: (tileHeader: Object) => void;
 		onTileError?: (tileHeader: Object, url: string, message: string) => void;
 	}
-	export default class Tile3DLayer<D> extends CompositeLayer<D> {
+	export default class Tile3DLayer<D, P extends Tile3DLayerProps<D> = Tile3DLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: Tile3DLayerProps<D>);
 		initializeState(params: any): void;
 		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
@@ -458,7 +458,7 @@ declare module "@deck.gl/geo-layers/terrain-layer/terrain-layer" {
 		wireframe?: boolean;
 		material?: any;
 	}
-	export default class TerrainLayer<D> extends CompositeLayer<D> {
+	export default class TerrainLayer<D, P extends TerrainLayerProps<D> = TerrainLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: TerrainLayerProps<D>);
 		updateState({
 			props,
@@ -520,8 +520,8 @@ declare module "@deck.gl/geo-layers/mvt-layer/clip-extension" {
 	}
 }
 declare module "@deck.gl/geo-layers/mvt-layer/mvt-layer" {
-	import TileLayer from "@deck.gl/geo-layers/tile-layer/tile-layer";
-	export default class MVTLayer<D> extends TileLayer<D> {
+	import TileLayer, { TileLayerProps } from "@deck.gl/geo-layers/tile-layer/tile-layer";
+	export default class MVTLayer<D, P extends TileLayerProps<D> = TileLayerProps<D>> extends TileLayer<D, P> {
 		getTileData(tile: any): any;
 		renderSubLayers(props: any): any;
 	}

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -468,7 +468,7 @@ declare module "@deck.gl/layers/column-layer/grid-cell-layer" {
 		getColor?: ((d: D) => RGBAColor) | RGBAColor;
 		getElevation?: ((d: D) => number) | number;
 	}
-	export default class GridCellLayer<D> extends ColumnLayer<D> {
+	export default class GridCellLayer<D, P extends GridCellLayerProps<D> = GridCellLayerProps<D>> extends ColumnLayer<D, P> {
 		constructor(props: GridCellLayerProps<D>);
 		getGeometry(diskResolution: any): any;
 		draw({ uniforms }: { uniforms: any }): void;
@@ -730,7 +730,7 @@ declare module "@deck.gl/layers/polygon-layer/polygon-layer" {
 		getLineWidth?: ((x: D) => number) | number;
 		getElevation?: ((x: D) => number) | number;
 	}
-	export default class PolygonLayer<D> extends CompositeLayer<D> {
+	export default class PolygonLayer<D, P extends PolygonLayerProps<D> = PolygonLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: PolygonLayerProps<D>);
 		initializeState(params: any): void;
 		updateState({
@@ -802,7 +802,7 @@ declare module "@deck.gl/layers/geojson-layer/geojson-layer" {
 		getLineWidth?: ((d: D) => number) | number;
 		getElevation?: ((d: D) => number) | number;
 	}
-	export default class GeoJsonLayer<D> extends CompositeLayer<D> {
+	export default class GeoJsonLayer<D, P extends GeoJsonLayerProps<D> = GeoJsonLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: GeoJsonLayerProps<D>);
 		initializeState(params: any): void;
 		updateState({ props, changeFlags }: { props: any; changeFlags: any }): void;
@@ -1020,7 +1020,7 @@ declare module "@deck.gl/layers/text-layer/text-layer" {
 		getAlignmentBaseline?: ((x: D) => AlignmentBaseline) | AlignmentBaseline;
 		getPixelOffset?: ((x: D) => number[]) | number[];
 	}
-	export default class TextLayer<D> extends CompositeLayer<D> {
+	export default class TextLayer<D, P extends TextLayerProps<D> = TextLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: TextLayerProps<D>);
 		initializeState(params: any): void;
 		updateState({


### PR DESCRIPTION
Pass correct props type to base and allow extension in derived layers

Layers deriving from `CompositeLayer` did not (always) pass their corresponding `*Props` type to the base class - causing type errors for props not present in `CompositeLayerProps`.
Additionally it can be convenient to derive from these layers and add additional props - use the same pattern as for layers derived from `Layer` directly to enable that.