### PR TITLE
add ObjectInfo parameter to attribute accessors

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1112,6 +1112,19 @@ declare module "@deck.gl/core/lib/layer" {
 	export type DataSet<D> = Iterable<D>;
 	export type WidthUnits = "meters" | "pixels";
 
+	export interface ObjectInfo<D,T> {
+		// the index of the current iteration
+		index: number;
+		// the value of the 'data' prop on the layer.
+		data: DataSet<D> | Promise<DataSet<D>> | string;
+		// a pre-allocated array.
+		// the accessor function can optionally fill data into this array and
+		// return it, instead of creating a new array for every object.
+		// In some browsers this improves performance significantly by
+		// reducing garbage collection.
+		target: T[];
+	}
+
 	// | AsyncIterable ToDo: Add AsyncIterable
 	// | { length: number } Todo: Support non-iterable objects, see deck.gl docs: /docs/developer-guide/using-layers.md#accessors
 

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -172,7 +172,7 @@ declare module "@deck.gl/layers/icon-layer/icon-manager" {
 }
 declare module "@deck.gl/layers/icon-layer/icon-layer" {
 	import { Layer } from "@deck.gl/core";
-	import { LayerProps, WidthUnits } from "@deck.gl/core/lib/layer";
+	import { ObjectInfo, LayerProps, WidthUnits } from "@deck.gl/core/lib/layer";
 	import { Position, Position2D } from "@deck.gl/core/utils/positions";
 	import Texture2D from "@luma.gl/webgl/classes/texture-2d";
 	import { RGBAColor } from "@deck.gl/core/utils/color";
@@ -223,11 +223,11 @@ declare module "@deck.gl/layers/icon-layer/icon-layer" {
 		getIcon?: (
 			x: D
 		) => string | ({ url: string; id?: string } & IconDefinitionBase);
-		getPosition?: (x: D) => Position;
-		getSize?: ((x: D) => number) | number;
-		getColor?: ((x: D) => RGBAColor) | RGBAColor;
-		getAngle?: ((x: D) => number) | number;
-		getPixelOffset?: ((x: D) => Position2D) | Position2D;
+		getPosition?: (x: D, objectInfo: ObjectInfo<D, Position>) => Position;
+		getSize?: ((x: D, objectInfo: ObjectInfo<D, number>) => number) | number;
+		getColor?: ((x: D, objectInfo: ObjectInfo<D, RGBAColor>) => RGBAColor) | RGBAColor;
+		getAngle?: ((x: D, objectInfo: ObjectInfo<D, number>) => number) | number;
+		getPixelOffset?: ((x: D, objectInfo: ObjectInfo<D, Position2D>) => Position2D) | Position2D;
 	}
 
 	export default class IconLayer<D, P extends IconLayerProps<D> = IconLayerProps<D>> extends Layer<D, P> {
@@ -993,9 +993,10 @@ declare module "@deck.gl/layers/text-layer/text-layer" {
 	import { FontSettings } from "@deck.gl/layers/text-layer/font-atlas-manager";
 	import { RGBAColor } from "@deck.gl/core/utils/color";
 	import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
-	import { WidthUnits } from "@deck.gl/core/lib/layer";
+	import { ObjectInfo, WidthUnits } from "@deck.gl/core/lib/layer";
 	export type TextAnchor = "start" | "middle" | "end";
 	export type AlignmentBaseline = "top" | "center" | "bottom";
+
 	export interface TextLayerProps<D> extends CompositeLayerProps<D> {
 		sizeScale?: number;
 		sizeUnits?: WidthUnits;
@@ -1012,11 +1013,11 @@ declare module "@deck.gl/layers/text-layer/text-layer" {
 		maxWidth?: number;
 
 		//Data Accessors
-		getText?: (x: D) => string;
-		getPosition?: (x: D) => [number, number];
-		getSize?: ((x: D) => number) | number;
-		getColor?: ((x: D) => RGBAColor) | RGBAColor;
-		getAngle?: ((x: D) => number) | number;
+		getText?: (x: D, objectInfo: ObjectInfo<D, string>) => string;
+		getPosition?: (x: D, objectInfo: ObjectInfo<D, [number, number]>) => [number, number];
+		getSize?: ((x: D, objectInfo: ObjectInfo<D, number>) => number) | number;
+		getColor?: ((x: D, objectInfo: ObjectInfo<D, RGBAColor>) => RGBAColor) | RGBAColor;
+		getAngle?: ((x: D, objectInfo: ObjectInfo<D, number>) => number) | number;
 
 		//Text Alignment Options
 		getTextAnchor?: ((x: D) => TextAnchor) | TextAnchor;


### PR DESCRIPTION
As documented here -
https://deck.gl/docs/developer-guide/using-layers#accessors - accessor
functions receives 2 arguments, the object (D) and objectInfo.
ObjectInfo includes contextual information of the current element.