### PR TITLE
Fix missing deck member

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2355,6 +2355,8 @@ declare module "@deck.gl/core/lib/deck" {
 		constructor(props: DeckProps);
 		canvas: HTMLCanvasElement;
 		viewState: any;
+		width: number;
+		height: number;
 		finalize(): void;
 		props: DeckProps;
 		setProps(props: Partial<DeckProps>): void;

--- a/deck.gl__react/index.d.ts
+++ b/deck.gl__react/index.d.ts
@@ -59,7 +59,7 @@ declare module "@deck.gl/react/utils/extract-styles" {
 	};
 }
 declare module "@deck.gl/react/deckgl" {
-	import { DeckProps } from '@deck.gl/core/lib/deck';
+	import Deck, { DeckProps } from '@deck.gl/core/lib/deck';
 	type propsNowOptional = 'width'|'height'|'effects'|'layers';
 	export type DeckGLProps = Omit<DeckProps, propsNowOptional> & Partial<Pick<DeckProps, propsNowOptional>>;
 	import { ReactElement } from "react";
@@ -77,6 +77,7 @@ declare module "@deck.gl/react/deckgl" {
 		_parseJSX(props: any): any;
 		_updateFromProps(props: any): void;
 		render(): ReactElement;
+		deck: Deck;
 	}
 }
 declare module "@deck.gl/react" {


### PR DESCRIPTION
This adds a missing member to the DeckGL react component and two for the Deck object.
Together this makes it possible to use e.g. fitBounds from (math.gl)[https://math.gl/modules/web-mercator/docs/api-reference/web-mercator-utils] which requires the size of the Deck canvas as input.