### PR TITLE
Provide stricter typing for updateState and shouldUpdateState

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1170,6 +1170,22 @@ declare module "@deck.gl/core/lib/layer" {
 		getPolygonOffset?: (uniform: any) => [number, number];
 		transitions?: { [attributeGetter: string]: TransitionTiming };
 	}
+	export interface LayerChangeFlags {
+		dataChanged: boolean | string | null;
+		propsChanged: boolean | string | null;
+		updateTriggersChanged: boolean | string | null;
+		viewportChanged: boolean | string | null;
+		stateChanged: boolean | string | null;
+		extensionsChanged: boolean | string | null;
+		propsOrDataChanged: boolean | string | null;
+		somethingChanged: boolean | string | null;
+	}
+	export interface UpdateStateInfo<P> {
+		oldProps: P;
+		props: P;
+		context: LayerContext;
+		changeFlags: LayerChangeFlags;
+	}
 	export interface DefaultPropType {
 		name: string;
 		value: any;
@@ -1209,23 +1225,13 @@ declare module "@deck.gl/core/lib/layer" {
 			props,
 			context,
 			changeFlags,
-		}: {
-			oldProps: any;
-			props: any;
-			context: any;
-			changeFlags: any;
-		}): any;
+		}: UpdateStateInfo<P>): any;
 		updateState({
 			oldProps,
 			props,
 			context,
 			changeFlags,
-		}: {
-			oldProps: any;
-			props: any;
-			context: any;
-			changeFlags: any;
-		}): void;
+		}: UpdateStateInfo<P>): void;
 		finalizeState(): void;
 		draw(opts: any): void;
 		getPickingInfo({ info, mode }: { info: any; mode: any }): any;


### PR DESCRIPTION
This introduces a type describing the argument to `Layer.shouldUpdateState` and `Layer.udpateState`: `UpdateStateInfo<P>` where `P` is the type of the layer's props.
It also adds a `LayerChangeFlags` type attempting to describe the changeFlags, but deck.gl seems to be not very consistent in what types it uses for those ☹️ - perhaps it would be better to just have `any` for the members of `LayerChangeFlags`?