### PR TITLE
Use RGBColor instead of RGBAColor where appropriate

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1067,7 +1067,7 @@ declare module "@deck.gl/core/lib/layer" {
 	import Component from "@deck.gl/core/lifecycle/component";
 	import Deck, { PickInfo } from "@deck.gl/core/lib/deck";
 	import * as hammerjs from "hammerjs";
-	import { RGBAColor } from "@deck.gl/core/utils/color";
+	import { RGBColor, RGBAColor } from "@deck.gl/core/utils/color";
 	import LayerManager from "@deck.gl/core/lib/layer-manager"
 	import Viewport from "@deck.gl/core/viewports/viewport";
 	import { Position } from "@deck.gl/core/utils/positions";
@@ -1216,9 +1216,9 @@ declare module "@deck.gl/core/lib/layer" {
 		use64bitPositions(): boolean;
 		onHover(info: any, pickingEvent: any): any;
 		onClick(info: any, pickingEvent: any): any;
-		nullPickingColor(): RGBAColor;
-		encodePickingColor(i: any, target?: any[]): RGBAColor;
-		decodePickingColor(color: any): number;
+		nullPickingColor(): RGBColor;
+		encodePickingColor(i: any, target?: any[]): RGBColor;
+		decodePickingColor(color: RGBColor): number;
 		initializeState(params: any): void;
 		getShaders(shaders: any): any;
 		shouldUpdateState({
@@ -2894,6 +2894,7 @@ declare module "@deck.gl/core" {
 	export { Position, Position2D, Position3D } from "@deck.gl/core/utils/positions";
 }
 declare module "@deck.gl/core/utils/color" {
+	export type RGBColor = [number, number, number];
 	export type RGBAColor = [number, number, number, number?];
 	export type ColorDomain = [number, number];
 	export type ColorRange = [

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -54,7 +54,7 @@ declare module "@deck.gl/layers/bitmap-layer/bitmap-layer-fragment" {
 declare module "@deck.gl/layers/bitmap-layer/bitmap-layer" {
 	import { Layer } from "@deck.gl/core";
 	import { LayerProps } from "@deck.gl/core/lib/layer";
-	import { RGBAColor } from "@deck.gl/core/utils/color";
+	import { RGBAColor, RGBColor } from "@deck.gl/core/utils/color";
 	export interface BitmapLayerProps<D> extends LayerProps<D> {
 		//Data
 		image: any;
@@ -70,7 +70,7 @@ declare module "@deck.gl/layers/bitmap-layer/bitmap-layer" {
 		//Render Options
 		desaturate: number;
 		transparentColor: RGBAColor;
-		tintColor: [number, number, number];
+		tintColor: RGBColor;
 	}
 	export default class BitmapLayer<D, P extends BitmapLayerProps<D> = BitmapLayerProps<D>> extends Layer<D, P> {
 		constructor(props: BitmapLayerProps<D>);


### PR DESCRIPTION
Some places explicitly don't use/allow alpha values