### PR TITLE
More accurate getPickingInfo typings

### DIFF
--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -407,7 +407,6 @@ declare module "@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer"
 		updateState(opts: any): void;
 		renderLayers(): any;
 		finalizeState(): void;
-		getPickingInfo({ info, mode }: { info: any; mode: any }): any;
 		updateResults({
 			aggregationData,
 			maxData,
@@ -575,7 +574,6 @@ declare module "@deck.gl/aggregation-layers/utils/cpu-aggregator" {
 		getDimensionScale(props: any, dimensionUpdater: any): void;
 		getSubLayerDimensionAttribute(key: any, nullValue: any): (cell: any) => any;
 		getSubLayerAccessors(props: any): {};
-		getPickingInfo({ info }: { info: any }): any;
 		getAccessor(dimensionKey: any): any;
 	}
 }
@@ -615,7 +613,6 @@ declare module "@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer" {
 		constructor(props: CPUGridLayerProps<D>);
 		initializeState(params: any): void;
 		updateState(opts: any): void;
-		getPickingInfo({ info }: { info: any }): any;
 		_onGetSublayerColor(cell: any): any;
 		_onGetSublayerElevation(cell: any): any;
 		_getSublayerUpdateTriggers(): any;
@@ -699,7 +696,6 @@ declare module "@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer" {
 		updateState(opts: any): void;
 		updateRadiusAngle(vertices: any): void;
 		convertLatLngToMeterOffset(hexagonVertices: any): number[][];
-		getPickingInfo({ info }: { info: any }): any;
 		_onGetSublayerColor(cell: any): any;
 		_onGetSublayerElevation(cell: any): any;
 		_getSublayerUpdateTriggers(): any;
@@ -884,7 +880,6 @@ declare module "@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer" {
 		updateState(opts: any): void;
 		getHashKeyForIndex(index: any): string;
 		getPositionForIndex(index: any): any[];
-		getPickingInfo({ info, mode }: { info: any; mode: any }): any;
 		renderLayers(): any;
 		finalizeState(): void;
 		updateAggregationState(opts: any): void;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1065,7 +1065,7 @@ declare module "@deck.gl/core/lib/layer-state" {
 declare module "@deck.gl/core/lib/layer" {
 	import AttributeManager from "@deck.gl/core/lib/attribute/attribute-manager";
 	import Component from "@deck.gl/core/lifecycle/component";
-	import Deck, { PickInfo } from "@deck.gl/core/lib/deck";
+	import Deck, { PickInfo, PickMode } from "@deck.gl/core/lib/deck";
 	import * as hammerjs from "hammerjs";
 	import { RGBAColor } from "@deck.gl/core/utils/color";
 	import LayerManager from "@deck.gl/core/lib/layer-manager"
@@ -1235,7 +1235,7 @@ declare module "@deck.gl/core/lib/layer" {
 		}: UpdateStateInfo<P>): void;
 		finalizeState(): void;
 		draw(opts: { moduleParameters: any, uniforms: any, parameters: any, context: WebGLRenderingContext }): void;
-		getPickingInfo({ info, mode }: { info: any; mode: any }): any;
+		getPickingInfo({ info, mode, sourceLayer }: { info: PickInfo<D>; mode: PickMode, sourceLayer: Layer<any> }): PickInfo<D>;
 		invalidateAttribute(name?: string, diffReason?: string): void;
 		updateAttributes(changedAttributes: any): void;
 		_updateAttributes(props: any): void;
@@ -1300,7 +1300,6 @@ declare module "@deck.gl/core/lib/composite-layer" {
 		getSubLayers(): any;
 		initializeState(params?: any): void;
 		setState(updateObject: any): void;
-		getPickingInfo({ info }: { info: any }): any;
 		renderLayers(): any;
 		shouldRenderSubLayer(id: any, data: any): any;
 		getSubLayerClass(id: any, DefaultLayerClass: any): any;
@@ -2282,6 +2281,7 @@ declare module "@deck.gl/core/lib/deck" {
 	import Viewport from "@deck.gl/core/viewports/viewport";
 	import TransitionInterpolator from "@deck.gl/core/transitions/transition-interpolator";
 	import { TRANSITION_EVENTS } from "@deck.gl/core/controllers/transition-manager";
+	import { Position } from "@deck.gl/core/utils/positions";
 
 	export interface InteractiveState {
 		isDragging: boolean;
@@ -2293,8 +2293,11 @@ declare module "@deck.gl/core/lib/deck" {
 		object: D;
 		x: number;
 		y: number;
-		coordinate?: {};
+		coordinate?: Position;
+		picked?: boolean;
 	}
+
+	export type PickMode = "hover" | "click";
 
 	// https://deck.gl/docs/api-reference/core/deck#viewstate
 	export interface InitialViewStateProps {

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -263,7 +263,6 @@ declare module "@deck.gl/geo-layers/tile-layer/tile-layer" {
 		_onTileError(error: any): void;
 		getTileData(tile: any): any;
 		renderSubLayers(props: any): any;
-		getPickingInfo({ info, sourceLayer }: { info: any; sourceLayer: any }): any;
 		renderLayers(): any;
 	}
 }
@@ -416,7 +415,6 @@ declare module "@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer" {
 			oldProps: Tile3DLayerProps<D>;
 			changeFlags: any;
 		}): void;
-		getPickingInfo({ info, sourceLayer }: { info: any; sourceLayer: any }): any;
 		_loadTileset(tilesetUrl: any): Promise<void>;
 		_onTileLoad(tileHeader: any): void;
 		_onTileUnload(tileHeader: any): void;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -539,7 +539,6 @@ declare module "@deck.gl/layers/path-layer/path-layer" {
 			props: P;
 			changeFlags: any;
 		}): void;
-		getPickingInfo(params: any): any;
 		draw({ uniforms }: { uniforms: any }): void;
 		_getModel(gl: any): any;
 		calculatePositions(attribute: any): void;
@@ -663,7 +662,6 @@ declare module "@deck.gl/layers/solid-polygon-layer/solid-polygon-layer" {
 	export default class SolidPolygonLayer<D, P extends SolidPolygonLayerProps<D> = SolidPolygonLayerProps<D>> extends Layer<D, P> {
 		getShaders(vs: any): any;
 		initializeState(params: any): void;
-		getPickingInfo(params: any): any;
 		draw({ uniforms }: { uniforms: any }): void;
 		updateState(updateParams: any): void;
 		updateGeometry({
@@ -1037,7 +1035,6 @@ declare module "@deck.gl/layers/text-layer/text-layer" {
 			changeFlags: any;
 		}): void;
 		finalizeState(): void;
-		getPickingInfo({ info }: { info: any }): any;
 		_updateFontAtlas(oldProps: any, props: any): void;
 		_fontChanged(oldProps: any, props: any): boolean;
 		_updateText(): void;


### PR DESCRIPTION
* Updated Layer.getPickingInfo to be more correct
* Removed getPickingInfo methods from Layer subclasses, since it's a core lifecycle method and there are no actual signature changes in subclasses