### PR TITLE
Ensure consistent Layer interfaces, remove updateState from Layer subclasses

### DIFF
--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -9,7 +9,6 @@ declare module "@deck.gl/aggregation-layers/aggregation-layer" {
 	export default class AggregationLayer<D, P extends AggregationLayerProps<D> = AggregationLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: AggregationLayerProps<D>);
 		initializeState(dimensions: any): void;
-		updateState(opts: any): void;
 		updateAttributes(changedAttributes: any): void;
 		getAttributes(): any;
 		getModuleSettings(): any;
@@ -309,7 +308,6 @@ declare module "@deck.gl/aggregation-layers/grid-aggregation-layer" {
 	export default class GridAggregationLayer<D, P extends GridAggregationLayerProps<D> = GridAggregationLayerProps<D>> extends AggregationLayer<D, P> {
 		constructor(props: GridAggregationLayerProps<D>);
 		initializeState({ dimensions }: { dimensions: any }): void;
-		updateState(opts: any): void;
 		finalizeState(): void;
 		updateShaders(shaders: any): void;
 		updateAggregationState(opts: any): void;
@@ -358,16 +356,6 @@ declare module "@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-cell-l
 			modules: any[];
 		};
 		initializeState(params: any): void;
-		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
-		updateState({
-			oldProps,
-			props,
-			changeFlags,
-		}: {
-			oldProps: ScreenGridCellLayerProps<D>;
-			props: ScreenGridCellLayerProps<D>;
-			changeFlags: any;
-		}): void;
 		draw({ uniforms }: { uniforms: any }): void;
 		calculateInstancePositions(
 			attribute: any,
@@ -403,8 +391,6 @@ declare module "@deck.gl/aggregation-layers/screen-grid-layer/screen-grid-layer"
 	export default class ScreenGridLayer<D, P extends ScreenGridLayerProps<D> = ScreenGridLayerProps<D>> extends GridAggregationLayer<D, P> {
 		constructor(props: ScreenGridLayerProps<D>);
 		initializeState(params: any): void;
-		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
-		updateState(opts: any): void;
 		renderLayers(): any;
 		finalizeState(): void;
 		updateResults({
@@ -612,7 +598,6 @@ declare module "@deck.gl/aggregation-layers/cpu-grid-layer/cpu-grid-layer" {
 	export default class CPUGridLayer<D, P extends CPUGridLayerProps<D> = CPUGridLayerProps<D>> extends AggregationLayer<D, P> {
 		constructor(props: CPUGridLayerProps<D>);
 		initializeState(params: any): void;
-		updateState(opts: any): void;
 		_onGetSublayerColor(cell: any): any;
 		_onGetSublayerElevation(cell: any): any;
 		_getSublayerUpdateTriggers(): any;
@@ -691,9 +676,7 @@ declare module "@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer" {
 	}
 	export default class HexagonLayer<D, P extends HexagonLayerProps<D> = HexagonLayerProps<D>> extends AggregationLayer<D, P> {
 		constructor(props: HexagonLayerProps<D>);
-		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
 		initializeState(params: any): void;
-		updateState(opts: any): void;
 		updateRadiusAngle(vertices: any): void;
 		convertLatLngToMeterOffset(hexagonVertices: any): number[][];
 		_onGetSublayerColor(cell: any): any;
@@ -791,7 +774,6 @@ declare module "@deck.gl/aggregation-layers/contour-layer/contour-layer" {
 	export default class ContourLayer<D, P extends ContourLayerProps<D> = ContourLayerProps<D>> extends GridAggregationLayer<D, P> {
 		constructor(props: ContourLayerProps<D>);
 		initializeState(params: any): void;
-		updateState(opts: any): void;
 		renderLayers(): any[];
 		updateAggregationState(opts: any): void;
 		_updateAccessors(opts: any): void;
@@ -877,7 +859,6 @@ declare module "@deck.gl/aggregation-layers/gpu-grid-layer/gpu-grid-layer" {
 	export default class GPUGridLayer<D, P extends GPUGridLayerProps<D> = GPUGridLayerProps<D>> extends GridAggregationLayer<D, P> {
 		constructor(props: GPUGridLayerProps<D>);
 		initializeState(params: any): void;
-		updateState(opts: any): void;
 		getHashKeyForIndex(index: any): string;
 		getPositionForIndex(index: any): any[];
 		renderLayers(): any;
@@ -925,15 +906,6 @@ declare module "@deck.gl/aggregation-layers/grid-layer/grid-layer" {
 	export default class GridLayer<D, P extends GridLayerProps<D> = GridLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: GridLayerProps<D>);
 		initializeState(params: any): void;
-		updateState({
-			oldProps,
-			props,
-			changeFlags,
-		}: {
-			oldProps: any;
-			props: any;
-			changeFlags: any;
-		}): void;
 		renderLayers(): any;
 		canUseGPUAggregation(props: any): boolean;
 	}
@@ -1014,8 +986,6 @@ declare module "@deck.gl/aggregation-layers/heatmap-layer/heatmap-layer" {
 	export default class HeatmapLayer<D, P extends HeatmapLayerProps<D> = HeatmapLayerProps<D>> extends AggregationLayer<D, P> {
 		constructor(props: HeatmapLayerProps<D>);
 		initializeState(params: any): void;
-		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
-		updateState(opts: any): void;
 		renderLayers(): any;
 		finalizeState(): void;
 		_getAttributeManager(): any;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1274,12 +1274,7 @@ declare module "@deck.gl/core/lib/layer" {
 		validateProps(): void;
 		setModuleParameters(moduleParameters: any): void;
 		_updateModules({ props, oldProps }: { props: any; oldProps: any }): void;
-		_getUpdateParams(): {
-			props: any;
-			oldProps: any;
-			context: any;
-			changeFlags: any;
-		};
+		_getUpdateParams(): UpdateStateInfo<P>;
 		_getNeedsRedraw(opts: any): boolean;
 		_getAttributeManager(): AttributeManager;
 		_initState(): void;

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -247,18 +247,6 @@ declare module "@deck.gl/geo-layers/tile-layer/tile-layer" {
 		constructor(props: TileLayerProps<D>);
 		initializeState(params: any): void;
 		get isLoaded(): any;
-		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
-		updateState({
-			props,
-			oldProps,
-			context,
-			changeFlags,
-		}: {
-			props: any;
-			oldProps: any;
-			context: any;
-			changeFlags: any;
-		}): void;
 		_updateTileset(): void;
 		_onTileLoad(tile: any): void;
 		_onTileError(error: any): void;
@@ -302,17 +290,8 @@ declare module "@deck.gl/geo-layers/h3-layers/h3-cluster-layer" {
 	export interface H3ClusterLayerProps<D> extends PolygonLayerProps<D> { 
 		getHexagons?: (d: D) => string[];
 	}
-	export default class H3ClusterLayer<D, P extends H3ClusterLayerProps<D>> extends CompositeLayer<D, P> {
+	export default class H3ClusterLayer<D, P extends H3ClusterLayerProps<D> = H3ClusterLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: H3ClusterLayerProps<D>);
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: H3ClusterLayerProps<D>;
-			oldProps: H3ClusterLayerProps<D>;
-			changeFlags: any;
-		}): void;
 		renderLayers(): any;
 	}
 }
@@ -340,16 +319,6 @@ declare module "@deck.gl/geo-layers/h3-layers/h3-hexagon-layer" {
 	 */
 	export default class H3HexagonLayer<D, P extends H3HexagonLayerProps<D> = H3HexagonLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: H3HexagonLayerProps<D>);
-		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: any;
-			oldProps: any;
-			changeFlags: any;
-		}): void;
 		_shouldUseHighPrecision(): any;
 		_updateVertices(viewport: any): void;
 		renderLayers(): any;
@@ -406,16 +375,6 @@ declare module "@deck.gl/geo-layers/tile-3d-layer/tile-3d-layer" {
 	export default class Tile3DLayer<D, P extends Tile3DLayerProps<D> = Tile3DLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: Tile3DLayerProps<D>);
 		initializeState(params: any): void;
-		shouldUpdateState({ changeFlags }: { changeFlags: any }): any;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: Tile3DLayerProps<D>;
-			oldProps: Tile3DLayerProps<D>;
-			changeFlags: any;
-		}): void;
 		_loadTileset(tilesetUrl: any): Promise<void>;
 		_onTileLoad(tileHeader: any): void;
 		_onTileUnload(tileHeader: any): void;
@@ -468,13 +427,6 @@ declare module "@deck.gl/geo-layers/terrain-layer/terrain-layer" {
 	}
 	export default class TerrainLayer<D, P extends TerrainLayerProps<D> = TerrainLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: TerrainLayerProps<D>);
-		updateState({
-			props,
-			oldProps,
-		}: {
-			props: TerrainLayerProps<D>;
-			oldProps: TerrainLayerProps<D>;
-		}): void;
 		loadTerrain({
 			elevationData,
 			bounds,

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -30,15 +30,6 @@ declare module "@deck.gl/layers/arc-layer/arc-layer" {
 	export default class ArcLayer<D, P extends ArcLayerProps<D> = ArcLayerProps<D>> extends Layer<D, P> {
 		getShaders(): any;
 		initializeState(params: any): void;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: P;
-			oldProps: P;
-			changeFlags: any;
-		}): void;
 		draw({ uniforms }: { uniforms: any }): void;
 		_getModel(gl: any): any;
 	}
@@ -81,15 +72,6 @@ declare module "@deck.gl/layers/bitmap-layer/bitmap-layer" {
 		constructor(props: BitmapLayerProps<D>);
 		getShaders(): any;
 		initializeState(params: any): void;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: P;
-			oldProps: P;
-			changeFlags: any;
-		}): void;
 		finalizeState(): void;
 		calculatePositions(attributes: any): void;
 		_getModel(gl: any): any;
@@ -239,15 +221,6 @@ declare module "@deck.gl/layers/icon-layer/icon-layer" {
 		constructor(props: P);
 		getShaders(): any;
 		initializeState(params: any): void;
-		updateState({
-			oldProps,
-			props,
-			changeFlags,
-		}: {
-			oldProps: P;
-			props: P;
-			changeFlags: any;
-		}): void;
 		get isLoaded(): any;
 		finalizeState(): void;
 		draw({ uniforms }: { uniforms: any }): void;
@@ -286,15 +259,6 @@ declare module "@deck.gl/layers/line-layer/line-layer" {
 	export default class LineLayer<D, P extends LineLayerProps<D> = LineLayerProps<D>> extends Layer<D, P> {
 		getShaders(): any;
 		initializeState(params: any): void;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: P;
-			oldProps: P;
-			changeFlags: any;
-		}): void;
 		draw({ uniforms }: { uniforms: any }): void;
 		_getModel(gl: any): any;
 	}
@@ -323,15 +287,6 @@ declare module "@deck.gl/layers/point-cloud-layer/point-cloud-layer" {
 	export default class PointCloudLayer<D, P extends PointCloudLayerProps<D> = PointCloudLayerProps<D>> extends Layer<D, P> {
 		getShaders(id: any): any;
 		initializeState(params: any): void;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: P;
-			oldProps: P;
-			changeFlags: any;
-		}): void;
 		draw({ uniforms }: { uniforms: any }): void;
 		_getModel(gl: any): any;
 	}
@@ -372,15 +327,6 @@ declare module "@deck.gl/layers/scatterplot-layer/scatterplot-layer" {
 	export default class ScatterplotLayer<D, P extends ScatterplotLayerProps<D> = ScatterplotLayerProps<D>> extends Layer<D, P> {
 		getShaders(id: any): any;
 		initializeState(params: any): void;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: P;
-			oldProps: P;
-			changeFlags: any;
-		}): void;
 		draw({ uniforms }: { uniforms: any }): void;
 		_getModel(gl: any): any;
 	}
@@ -435,15 +381,6 @@ declare module "@deck.gl/layers/column-layer/column-layer" {
 		 * Essentially a deferred constructor
 		 */
 		initializeState(params: any): void;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: P;
-			oldProps: P;
-			changeFlags: any;
-		}): void;
 		getGeometry(diskResolution: any, vertices: any): ColumnGeometry;
 		_getModel(gl: any): any;
 		_updateGeometry({
@@ -535,15 +472,6 @@ declare module "@deck.gl/layers/path-layer/path-layer" {
 	export default class PathLayer<D, P extends PathLayerProps<D> = PathLayerProps<D>> extends Layer<D, P> {
 		getShaders(): any;
 		initializeState(params: any): void;
-		updateState({
-			oldProps,
-			props,
-			changeFlags,
-		}: {
-			oldProps: P;
-			props: P;
-			changeFlags: any;
-		}): void;
 		draw({ uniforms }: { uniforms: any }): void;
 		_getModel(gl: any): any;
 		calculatePositions(attribute: any): void;
@@ -668,7 +596,6 @@ declare module "@deck.gl/layers/solid-polygon-layer/solid-polygon-layer" {
 		getShaders(vs: any): any;
 		initializeState(params: any): void;
 		draw({ uniforms }: { uniforms: any }): void;
-		updateState(updateParams: any): void;
 		updateGeometry({
 			props,
 			oldProps,
@@ -737,15 +664,6 @@ declare module "@deck.gl/layers/polygon-layer/polygon-layer" {
 	export default class PolygonLayer<D, P extends PolygonLayerProps<D> = PolygonLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: PolygonLayerProps<D>);
 		initializeState(params: any): void;
-		updateState({
-			oldProps,
-			props,
-			changeFlags,
-		}: {
-			oldProps: PolygonLayerProps<D>;
-			props: PolygonLayerProps<D>;
-			changeFlags: any;
-		}): void;
 		_getPaths(dataRange?: {}): any[];
 		renderLayers(): any[];
 	}
@@ -810,7 +728,6 @@ declare module "@deck.gl/layers/geojson-layer/geojson-layer" {
 	export default class GeoJsonLayer<D, P extends GeoJsonLayerProps<D> = GeoJsonLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: GeoJsonLayerProps<D>);
 		initializeState(params: any): void;
-		updateState({ props, changeFlags }: { props: any; changeFlags: any }): void;
 		renderLayers(): any[];
 		_getHighlightedIndex(data: any): any;
 	}
@@ -824,7 +741,6 @@ declare module "@deck.gl/layers/text-layer/multi-icon-layer/multi-icon-layer" {
 	export default class MultiIconLayer<D> extends IconLayer<D> {
 		getShaders(): any;
 		initializeState(params: any): void;
-		updateState(updateParams: any): void;
 		draw({ uniforms }: { uniforms: any }): void;
 		getInstanceOffset(icons: any): any[];
 		getInstanceColorMode(icons: any): number;
@@ -1030,15 +946,6 @@ declare module "@deck.gl/layers/text-layer/text-layer" {
 	export default class TextLayer<D, P extends TextLayerProps<D> = TextLayerProps<D>> extends CompositeLayer<D, P> {
 		constructor(props: TextLayerProps<D>);
 		initializeState(params: any): void;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: TextLayerProps<D>;
-			oldProps: TextLayerProps<D>;
-			changeFlags: any;
-		}): void;
 		finalizeState(): void;
 		_updateFontAtlas(oldProps: any, props: any): void;
 		_fontChanged(oldProps: any, props: any): boolean;

--- a/deck.gl__mesh-layers/index.d.ts
+++ b/deck.gl__mesh-layers/index.d.ts
@@ -73,15 +73,6 @@ declare module "@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer" {
 	export default class SimpleMeshLayer<D,P extends SimpleMeshLayerProps<D> = SimpleMeshLayerProps<D>> extends Layer<D,P> {
 		getShaders(): any;
 		initializeState(params: any): void;
-		updateState({
-			props,
-			oldProps,
-			changeFlags,
-		}: {
-			props: P;
-			oldProps: P;
-			changeFlags: any;
-		}): void;
 		finalizeState(): void;
 		draw({ uniforms }: { uniforms: any }): void;
 		getModel(mesh: any): any;
@@ -132,7 +123,6 @@ declare module "@deck.gl/mesh-layers/scenegraph-layer/scenegraph-layer" {
 	export default class ScenegraphLayer <D,P extends ScenegraphLayerProps<D> = ScenegraphLayerProps<D>> extends Layer<D,P> {
 		constructor(props: ScenegraphLayerProps<D>);
 		initializeState(params: any): void;
-		updateState(params: any): void;
 		finalizeState(): void;
 		_updateScenegraph(props: any): void;
 		_applyAllAttributes(scenegraph: any): void;

--- a/test/@deck.gl/ensure-consistent-layer-interfaces.ts
+++ b/test/@deck.gl/ensure-consistent-layer-interfaces.ts
@@ -1,0 +1,90 @@
+import { Layer } from "deck.gl";
+import {
+    ArcLayer,
+    BitmapLayer,
+    IconLayer,
+    LineLayer,
+    PointCloudLayer,
+    ScatterplotLayer,
+    GridCellLayer,
+    ColumnLayer,
+    PathLayer,
+    PolygonLayer,
+    SolidPolygonLayer,
+    GeoJsonLayer,
+    TextLayer,
+  } from "@deck.gl/layers";
+  import {
+    ScreenGridLayer,
+    CPUGridLayer,
+    HexagonLayer,
+    ContourLayer,
+    GridLayer,
+    GPUGridLayer,
+    HeatmapLayer,
+  } from "@deck.gl/aggregation-layers";
+  import {
+    GreatCircleLayer,
+    S2Layer,
+    H3ClusterLayer,
+    H3HexagonLayer,
+    TripsLayer,
+    Tile3DLayer,
+    TerrainLayer,
+    MVTLayer,
+  } from "@deck.gl/geo-layers";
+  import {
+    SimpleMeshLayer,
+    ScenegraphLayer,
+  } from "@deck.gl/mesh-layers";
+
+
+interface Datum { }
+
+export const testLayersArray: Layer<Datum>[] = [
+    new ArcLayer<Datum>({}),
+    new BitmapLayer<Datum>({
+        image: null,
+        bounds: [0,0,0,0],
+    }),
+    new IconLayer<Datum>({}),
+    new LineLayer<Datum>({}),
+    new PointCloudLayer<Datum>({}),
+    new ScatterplotLayer<Datum>({}),
+    new GridCellLayer<Datum>({}),
+    new ColumnLayer<Datum>({}),
+    new PathLayer<Datum>({}),
+    new PolygonLayer<Datum>({}),
+    new SolidPolygonLayer<Datum>({}),
+    new GeoJsonLayer<Datum>({}),
+    new TextLayer<Datum>({}),
+    new ScreenGridLayer<Datum>({}),
+    new CPUGridLayer<Datum>({}),
+    new HexagonLayer<Datum>({}),
+    new ContourLayer<Datum>({}),
+    new GridLayer<Datum>({}),
+    new GPUGridLayer<Datum>({}),
+    new HeatmapLayer<Datum>({}),
+    new GreatCircleLayer<Datum>({}),
+    new S2Layer<Datum>({
+        getS2Token: () => {}
+    }),
+    new H3ClusterLayer<Datum>({}),
+    new H3HexagonLayer<Datum>({}),
+    new TripsLayer<Datum>({}),
+    new Tile3DLayer<Datum>({}),
+    new TerrainLayer<Datum>({
+        elevationData: "",
+    }),
+    new MVTLayer<Datum>({}),
+    new SimpleMeshLayer<Datum>({
+        mesh: {
+            positions: new Float32Array(),
+            normals: new Float32Array(),
+            texCoords: new Float32Array(),
+        }
+    }),
+    new ScenegraphLayer<Datum>({
+        scenegraph: new URL(""),
+    }),
+];


### PR DESCRIPTION
- Added a test (test/@deck.gl/ensure-consistent-layer-interfaces.ts) to ensure all Layer subclasses conform to the Layer interface
- Remove all  `updateState` and `shouldUpdateState` methods from Layer subclasses, since it's a standard Layer lifecycle method (and the different signatures were causing issues)
- A few other minor fixes to ensure consistent Layer interfaces