### PR TITLE
Fixing getTooltip? return type declaration.

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2382,7 +2382,7 @@ declare module "@deck.gl/core/lib/deck" {
 		pickingRadius?: number;
 		getTooltip?: <D>(
 			info: PickInfo<D>
-		) => null | {
+		) => null | string | {
 			text?: string;
 			html?: string;
 			className?: string;


### PR DESCRIPTION
Small fix for solving issue https://github.com/danmarshall/deckgl-typings/issues/155, which is that `getTooltip?` in `DeckProps` had a missing return type according to the official documentation. More in-depth evidence in the linked issue.

------

Note: the linked issue was made by @argdiego, which is another account I have.