### PR TITLE
Missing props in DeckProps, optional width and height

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2377,6 +2377,7 @@ declare module "@deck.gl/core/lib/deck" {
 		//Configuration Properties
 		id?: string;
 		style?: {};
+		parent?: HTMLElement;
 		canvas?: HTMLCanvasElement;
 		touchAction?: string;
 		pickingRadius?: number;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2354,8 +2354,8 @@ declare module "@deck.gl/core/lib/deck" {
 	export interface DeckProps {
 		//https://deck.gl/#/documentation/deckgl-api-reference/deck?section=properties
 		// https://github.com/visgl/deck.gl/blob/e948740f801cf91b541a9d7f3bba143ceac34ab2/modules/react/src/deckgl.js#L71-L72
-		width: string | number;
-		height: string | number;
+		width?: string | number;
+		height?: string | number;
 		layers: Layer<any>[];
 		layerFilter?: (args: {
 			layer: Layer<any>;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2353,20 +2353,20 @@ declare module "@deck.gl/core/lib/deck" {
 
 	export interface DeckProps {
 		//https://deck.gl/docs/api-reference/core/deck#properties
-		width?: string | number;
-		height?: string | number;
+		width: string | number;
+		height: string | number;
 		layers: Layer<any>[];
-		layerFilter?: (args: {
+		layerFilter: (args: {
 			layer: Layer<any>;
 			viewport: Viewport;
 			isPicking: boolean;
 			renderPass: string;
 		}) => boolean;
-		getCursor?: (interactiveState: InteractiveState) => string;
-		views?: View[];
-		viewState?: ViewStateProps;
-		initialViewState?: InitialViewStateProps;
-		controller?: null | Controller | ControllerOptions | boolean;
+		getCursor: (interactiveState: InteractiveState) => string;
+		views: View[];
+		viewState: ViewStateProps;
+		initialViewState: InitialViewStateProps;
+		controller: null | Controller | ControllerOptions | boolean;
 		effects: Effect[];
 		_typedArrayManagerProps?: {
 			overAlloc?: number;
@@ -2374,13 +2374,13 @@ declare module "@deck.gl/core/lib/deck" {
 		};
 
 		//Configuration Properties
-		id?: string;
-		style?: {};
-		parent?: HTMLElement;
-		canvas?: HTMLCanvasElement;
-		touchAction?: string;
-		pickingRadius?: number;
-		getTooltip?: <D>(
+		id: string;
+		style: {};
+		parent: HTMLElement;
+		canvas: HTMLCanvasElement;
+		touchAction: string;
+		pickingRadius: number;
+		getTooltip: <D>(
 			info: PickInfo<D>
 		) => null | string | {
 			text?: string;
@@ -2388,18 +2388,18 @@ declare module "@deck.gl/core/lib/deck" {
 			className?: string;
 			style?: {};
 		};
-		useDevicePixels?: boolean | number;
-		gl?: WebGLRenderingContext;
-		glOptions?: WebGLContextAttributes;
-		_framebuffer?: any;
-		parameters?: object;
-		debug?: boolean;
-		_animate?: boolean;
-		_pickable?: boolean;
+		useDevicePixels: boolean | number;
+		gl: WebGLRenderingContext;
+		glOptions: WebGLContextAttributes;
+		_framebuffer: any;
+		parameters: object;
+		debug: boolean;
+		_animate: boolean;
+		_pickable: boolean;
 
 		//Event Callbacks
-		onWebGLInitialized?: (gl: WebGLRenderingContext) => any;
-		onViewStateChange?: (args: {
+		onWebGLInitialized: (gl: WebGLRenderingContext) => any;
+		onViewStateChange: (args: {
 			viewState: any;
 			interactionState: {
 				inTransition?: boolean;
@@ -2410,23 +2410,23 @@ declare module "@deck.gl/core/lib/deck" {
 			};
 			oldViewState: any;
 		}) => any;
-		onHover?: <D>(info: PickInfo<D>, e: MouseEvent) => any;
-		onClick?: <D>(info: PickInfo<D>, e: MouseEvent) => any;
-		onDragStart?: <D>(info: PickInfo<D>, e: MouseEvent) => any;
-		onDrag?: <D>(info: PickInfo<D>, e: MouseEvent) => any;
-		onDragEnd?: <D>(info: PickInfo<D>, e: MouseEvent) => any;
-		onLoad?: () => void;
-		onResize?: (size: { height: number; width: number }) => void;
-		onBeforeRender?: (args: { gl: WebGLRenderingContext }) => void;
-		onAfterRender?: (args: { gl: WebGLRenderingContext }) => void;
-		onError?: (error: Error, source: any) => void;
-		_onMetrics?: (metrics: MetricsPayload) => void;
+		onHover: <D>(info: PickInfo<D>, e: MouseEvent) => any;
+		onClick: <D>(info: PickInfo<D>, e: MouseEvent) => any;
+		onDragStart: <D>(info: PickInfo<D>, e: MouseEvent) => any;
+		onDrag: <D>(info: PickInfo<D>, e: MouseEvent) => any;
+		onDragEnd: <D>(info: PickInfo<D>, e: MouseEvent) => any;
+		onLoad: () => void;
+		onResize: (size: { height: number; width: number }) => void;
+		onBeforeRender: (args: { gl: WebGLRenderingContext }) => void;
+		onAfterRender: (args: { gl: WebGLRenderingContext }) => void;
+		onError: (error: Error, source: any) => void;
+		_onMetrics: (metrics: MetricsPayload) => void;
 
-		ContextProvider?: React.Provider<ContextProviderValue>
+		ContextProvider: React.Provider<ContextProviderValue>
 	}
 
 	export default class Deck {
-		constructor(props: DeckProps);
+		constructor(props: Partial<DeckProps>);
 		canvas: HTMLCanvasElement;
 		viewState: any;
 		width: number;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2352,8 +2352,7 @@ declare module "@deck.gl/core/lib/deck" {
 	}
 
 	export interface DeckProps {
-		//https://deck.gl/#/documentation/deckgl-api-reference/deck?section=properties
-		// https://github.com/visgl/deck.gl/blob/e948740f801cf91b541a9d7f3bba143ceac34ab2/modules/react/src/deckgl.js#L71-L72
+		//https://deck.gl/docs/api-reference/core/deck#properties
 		width?: string | number;
 		height?: string | number;
 		layers: Layer<any>[];

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2396,6 +2396,7 @@ declare module "@deck.gl/core/lib/deck" {
 		parameters?: object;
 		debug?: boolean;
 		_animate?: boolean;
+		_pickable?: boolean;
 
 		//Event Callbacks
 		onWebGLInitialized?: (gl: WebGLRenderingContext) => any;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2368,7 +2368,7 @@ declare module "@deck.gl/core/lib/deck" {
 		initialViewState: InitialViewStateProps;
 		controller: null | Controller | ControllerOptions | boolean;
 		effects: Effect[];
-		_typedArrayManagerProps?: {
+		_typedArrayManagerProps: {
 			overAlloc?: number;
 			poolSize?: number;
 		};


### PR DESCRIPTION
Added properties:
 ```
parent?: HTMLElement;
pickable?: boolean;
```
Changed width and height to be optional:
```
width?: string | number;
height?: string | number;
```