### PR TITLE
Remove ContextProviderValue type to allow proper interop

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2344,13 +2344,6 @@ declare module "@deck.gl/core/lib/deck" {
 		updateAttributesTime: number;
 	}
 
-	export interface ContextProviderValue {
-		viewport: Viewport;
-		container: HTMLElement;
-		// @TODO: mjolnir.js types
-		eventManager: object;
-	}
-
 	export interface DeckProps {
 		//https://deck.gl/#/documentation/deckgl-api-reference/deck?section=properties
 		// https://github.com/visgl/deck.gl/blob/e948740f801cf91b541a9d7f3bba143ceac34ab2/modules/react/src/deckgl.js#L71-L72
@@ -2421,7 +2414,7 @@ declare module "@deck.gl/core/lib/deck" {
 		onError?: (error: Error, source: any) => void;
 		_onMetrics?: (metrics: MetricsPayload) => void;
 
-		ContextProvider?: React.Provider<ContextProviderValue>
+		ContextProvider?: React.Provider<any>
 	}
 
 	export default class Deck {

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2344,7 +2344,14 @@ declare module "@deck.gl/core/lib/deck" {
 		updateAttributesTime: number;
 	}
 
-	export interface DeckProps {
+	export interface ContextProviderValue {
+		viewport: Viewport;
+		container: HTMLElement;
+		// @TODO: mjolnir.js types
+		eventManager: object;
+	}
+
+	export interface DeckProps<T=ContextProviderValue> {
 		//https://deck.gl/#/documentation/deckgl-api-reference/deck?section=properties
 		// https://github.com/visgl/deck.gl/blob/e948740f801cf91b541a9d7f3bba143ceac34ab2/modules/react/src/deckgl.js#L71-L72
 		width: string | number;
@@ -2414,18 +2421,18 @@ declare module "@deck.gl/core/lib/deck" {
 		onError?: (error: Error, source: any) => void;
 		_onMetrics?: (metrics: MetricsPayload) => void;
 
-		ContextProvider?: React.Provider<any>
+		ContextProvider?: React.Provider<T>
 	}
 
-	export default class Deck {
-		constructor(props: DeckProps);
+	export default class Deck<T=ContextProviderValue> {
+		constructor(props: DeckProps<T>);
 		canvas: HTMLCanvasElement;
 		viewState: any;
 		width: number;
 		height: number;
 		finalize(): void;
-		props: DeckProps;
-		setProps(props: Partial<DeckProps>): void;
+		props: DeckProps<T>;
+		setProps(props: Partial<DeckProps<T>>): void;
 		needsRedraw(opts?: { clearRedrawFlags: boolean }): any;
 		redraw(force: any): void;
 		getViews(): any;

--- a/deck.gl__react/index.d.ts
+++ b/deck.gl__react/index.d.ts
@@ -59,12 +59,12 @@ declare module "@deck.gl/react/utils/extract-styles" {
 	};
 }
 declare module "@deck.gl/react/deckgl" {
-	import Deck, { DeckProps } from '@deck.gl/core/lib/deck';
+	import Deck, { ContextProviderValue, DeckProps } from '@deck.gl/core/lib/deck';
 	type propsNowOptional = 'width'|'height'|'effects'|'layers';
-	export type DeckGLProps = Omit<DeckProps, propsNowOptional> & Partial<Pick<DeckProps, propsNowOptional>>;
+	export type DeckGLProps<T=ContextProviderValue> = Omit<DeckProps<T>, propsNowOptional> & Partial<Pick<DeckProps<T>, propsNowOptional>>;
 	import { ReactElement } from "react";
-	export default class DeckGL extends React.Component<DeckGLProps> {
-		constructor(props: DeckGLProps);
+	export default class DeckGL<T=ContextProviderValue> extends React.Component<DeckGLProps<T>> {
+		constructor(props: DeckGLProps<T>);
 		componentDidMount(): void;
 		shouldComponentUpdate(nextProps: any): boolean;
 		componentDidUpdate(): void;


### PR DESCRIPTION
This solves #179 by changing the type of `DeckProps.ContextProvider` and removing a now unnecessary type.