### PR TITLE
hexagon: add colorScaleType prop

### DIFF
--- a/deck.gl__aggregation-layers/index.d.ts
+++ b/deck.gl__aggregation-layers/index.d.ts
@@ -652,6 +652,7 @@ declare module "@deck.gl/aggregation-layers/hexagon-layer/hexagon-layer" {
 		hexagonAggregator?: Function;
 		colorDomain?: ColorDomain;
 		colorRange?: ColorRange;
+		colorScaleType?: string;
 		coverage?: number;
 		elevationDomain?: [number, number];
 		elevationRange?: [number, number];


### PR DESCRIPTION
This is an undocumented prop that appears in the docs for some layers but not others.  It's definitely [in the original source code for Hexagon layer, though!](https://github.com/visgl/deck.gl/blob/master/modules/aggregation-layers/src/hexagon-layer/hexagon-layer.js#L41).  kepler.gl also lets folks change this behavior.