### PR TITLE
ColorRange: don't restrict to 6 colors

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2904,14 +2904,7 @@ declare module "@deck.gl/core/utils/color" {
 	export type RGBColor = [number, number, number];
 	export type RGBAColor = [number, number, number, number?];
 	export type ColorDomain = [number, number];
-	export type ColorRange = [
-		RGBAColor,
-		RGBAColor,
-		RGBAColor,
-		RGBAColor,
-		RGBAColor,
-		RGBAColor
-	];
+	export type ColorRange = RGBAColor[];
 	function parseColor(color: any, target: any, index?: number): any;
 	function applyOpacity(color: any, opacity?: number): any[];
 	const _default: {


### PR DESCRIPTION
I think ColorRange used to have a restriction capped at 6 colors, but it's more flexible now.

References:
* [deck.gl docs change](https://github.com/visgl/deck.gl/pull/5107/files)
* kepler.gl supports color palettes of multiple sizes