### PR TITLE
Simple addition to base layer data

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1128,7 +1128,7 @@ declare module "@deck.gl/core/lib/layer" {
 	export interface LayerProps<D> {
 		//https://deck.gl/#/documentation/deckgl-api-reference/layers/layer?section=properties
 		id?: string;
-		data?: DataSet<D> | Promise<DataSet<D>> | string;
+		data?: D | DataSet<D> | Promise<DataSet<D>> | string;
 		visible?: boolean;
 		opacity?: number;
 		extensions?: any[];


### PR DESCRIPTION
This solves #93, which prevents GeoJSON data from being accepted as the data parameter for the `GeoJsonLayer` type. This fix opens up the typing for all types.