### PR TITLE
Make all DeckGL props optional.

### DIFF
--- a/deck.gl__react/index.d.ts
+++ b/deck.gl__react/index.d.ts
@@ -60,8 +60,7 @@ declare module "@deck.gl/react/utils/extract-styles" {
 }
 declare module "@deck.gl/react/deckgl" {
 	import Deck, { ContextProviderValue, DeckProps } from '@deck.gl/core/lib/deck';
-	type propsNowOptional = 'width'|'height'|'effects'|'layers';
-	export type DeckGLProps<T=ContextProviderValue> = Omit<DeckProps<T>, propsNowOptional> & Partial<Pick<DeckProps<T>, propsNowOptional>>;
+	export type DeckGLProps<T=ContextProviderValue> = Partial<DeckProps<T>>;
 	import { ReactElement } from "react";
 	export default class DeckGL<T=ContextProviderValue> extends React.Component<DeckGLProps<T>> {
 		constructor(props: DeckGLProps<T>);


### PR DESCRIPTION
Fixes #189, but I'm not sure if there isn't a better way to do this. My first attempt used this:

```typescript
export type DekcGLProps<T=ContextProviderValue> = DeckProps<T>;
export default class DeckGL<T=ContextProviderValue> extends React.Component<DeckGLProps<T>> {
  constructor(props: Partial<DeckGLProps<T>>);
}
```
In other words put the `Partial` only on the constructor argument, but I was still getting the same error as in #189. Thoughts?
