### PR TITLE
LayerProps: parameters is an object, not a function

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1169,7 +1169,7 @@ declare module "@deck.gl/core/lib/layer" {
 		) => void;
 
 		//Render Properties
-		parameters?: () => any;
+		parameters?: any;
 		getPolygonOffset?: (uniform: any) => [number, number];
 		transitions?: { [attributeGetter: string]: TransitionTiming };
 	}


### PR DESCRIPTION
This documentation is incorrect: https://deck.gl/docs/api-reference/core/layer#parameters
The input is actually the argument to luma.gl `setParameters`.

I'll try to fix this independently in deck.gl, but I wanted to fix it here already.

Closes #87 

In the future, this will require further changes to reflect actually allowed luma.gl fields for this object.