### PR TITLE
fix PathLayer constructor params

### DIFF
--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -467,6 +467,7 @@ declare module "@deck.gl/layers/path-layer/path-layer" {
 		getWidth?: ((d: D) => number) | number;
 	}
 	export default class PathLayer<D, P extends PathLayerProps<D> = PathLayerProps<D>> extends Layer<D, P> {
+		constructor(props: PathLayerProps<D>);
 		getShaders(): any;
 		initializeState(params: any): void;
 		draw({ uniforms }: { uniforms: any }): void;


### PR DESCRIPTION
If constructor param of `PathLayer` is not specified, `new PathLayer()` will check type `LayerProps` instead of `PathLayerProps`. 