### PR TITLE
Added type for `getPolygon` data accessors.

### DIFF
--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -585,7 +585,7 @@ declare module "@deck.gl/layers/solid-polygon-layer/solid-polygon-layer" {
 		_normalize?: boolean;
 
 		//Data Accessors
-		getPolygon?: (x: D) => Position[];
+		getPolygon?: (x: D) => Position[] | Position[][];
 		getFillColor?: ((x: D) => RGBAColor) | RGBAColor;
 		getLineColor?: ((x: D) => RGBAColor) | RGBAColor;
 		getElevation?: ((x: D) => number) | number;
@@ -653,7 +653,7 @@ declare module "@deck.gl/layers/polygon-layer/polygon-layer" {
 		_normalize?: boolean;
 
 		//Data Accessors
-		getPolygon?: (x: D) => Position[];
+		getPolygon?: (x: D) => Position[] | Position[][];
 		getFillColor?: ((x: D) => RGBAColor) | RGBAColor;
 		getLineColor?: ((x: D) => RGBAColor) | RGBAColor;
 		getLineWidth?: ((x: D) => number) | number;


### PR DESCRIPTION
Deck.gl polygon layer can handle  different types of polygons with `Position[]` only one type is covered. 
Corresponding Deck.gl documentation: 
[https://deck.gl/docs/api-reference/layers/solid-polygon-layer#getpolygon](https://deck.gl/docs/api-reference/layers/solid-polygon-layer#getpolygon)
[https://deck.gl/docs/api-reference/layers/polygon-layer#getpolygon](https://deck.gl/docs/api-reference/layers/polygon-layer#getpolygon)
![image](https://user-images.githubusercontent.com/28397002/128936153-49e78862-630a-4eeb-a60c-8df9e3b56f20.png)

In order to handle Polygons with polygonal holes in it. It can accept array of `Position[]` where 1st element is actual outer poygon and following polygons are holes in it. 

previously: `getPolygon?: (x: D) => Position[];`
now: `getPolygon?: (x: D) => Position[] | Position[][];`

Note: adding Flat simple polygon and object of shape {positions, holeIndices} in order to avoid confusion of using getPolygon.

message: Pretty new to Deckgl and frontend programming and was stuck where I need polygon with holes for visulization.