### PR TITLE
reference to deck.gl/extensions (#214)

### DIFF
--- a/deck.gl/index.d.ts
+++ b/deck.gl/index.d.ts
@@ -5,6 +5,7 @@
 /// <reference path="../deck.gl__geo-layers/index.d.ts" />
 /// <reference path="../deck.gl__mesh-layers/index.d.ts" />
 /// <reference path="../deck.gl__react/index.d.ts" />
+/// <reference path="../deck.gl__extensions/index.d.ts" />
 
 declare module "deck.gl" {
   export {


### PR DESCRIPTION
After installing any package, We encounter this error: can not resolve @deck.gl/extensions.