### PR TITLE
Allow `viewState` to support decks with multiple views

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2380,7 +2380,7 @@ declare module "@deck.gl/core/lib/deck" {
 		}) => boolean;
 		getCursor: (interactiveState: InteractiveState) => string;
 		views: View[];
-		viewState: ViewStateProps;
+		viewState: ViewStateProps | { [key: string]: ViewStateProps };
 		initialViewState: InitialViewStateProps;
 		controller: null | Controller | ControllerOptions | boolean;
 		effects: Effect[];


### PR DESCRIPTION
DeckProps property viewState can be map of view id strings to different view states

Related to #216 