### PR TITLE
fix: getRadius -> getPointRadius

### DIFF
--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -719,7 +719,7 @@ declare module "@deck.gl/layers/geojson-layer/geojson-layer" {
 		//Data Accessors
 		getLineColor?: ((d: D) => RGBAColor) | RGBAColor;
 		getFillColor?: ((d: D) => RGBAColor) | RGBAColor;
-		getRadius?: ((d: D) => number) | number;
+		getPointRadius?: ((d: D) => number) | number;
 		getLineWidth?: ((d: D) => number) | number;
 		getElevation?: ((d: D) => number) | number;
 	}

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -722,6 +722,9 @@ declare module "@deck.gl/layers/geojson-layer/geojson-layer" {
 		getPointRadius?: ((d: D) => number) | number;
 		getLineWidth?: ((d: D) => number) | number;
 		getElevation?: ((d: D) => number) | number;
+
+		// getRadius is deprecated since deck.gl v8.5, use getPointRadius instead
+		getRadius?: ((d: D) => number) | number;
 	}
 	export default class GeoJsonLayer<D, P extends GeoJsonLayerProps<D> = GeoJsonLayerProps<D>> extends CompositeLayer<D, P> {
 		initializeState(params: any): void;


### PR DESCRIPTION
https://deck.gl/docs/upgrade-guide#deprecations

GeoJsonLayer's getRadius props is deprecated, replaced by getPointRadius.