### PR TITLE
Misc updates

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1608,6 +1608,8 @@ declare module '@deck.gl/core/controllers/transition-manager' {
 
 //https://github.com/visgl/deck.gl/blob/master/docs/api-reference/core/controller.md
 declare module '@deck.gl/core/controllers/controller' {
+  import { InteractionState } from '@deck.gl/core/lib/deck';
+  
   export interface ControllerOptions {
     scrollZoom?:
       | boolean
@@ -1650,7 +1652,7 @@ declare module '@deck.gl/core/controllers/controller' {
     setProps(props: any): void;
     updateTransition(): void;
     toggleEvents(eventNames: any, enabled: any): void;
-    updateViewport(newControllerState: any, extraProps?: {}, interactionState?: {}): void;
+    updateViewport(newControllerState: any, extraProps?: {}, interactionState?: InteractionState): void;
     _onPanStart(event: any): boolean;
     _onPan(event: any): boolean;
     _onPanEnd(event: any): boolean;
@@ -2181,6 +2183,14 @@ declare module '@deck.gl/core/lib/deck' {
     eventManager: object;
   }
 
+	export interface InteractionState {
+		inTransition?: boolean;
+		isDragging?: boolean;
+		isPanning?: boolean;
+		isRotating?: boolean;
+		isZooming?: boolean;
+	}
+
   export interface DeckProps<T = ContextProviderValue> {
     //https://deck.gl/#/documentation/deckgl-api-reference/deck?section=properties
     // https://github.com/visgl/deck.gl/blob/e948740f801cf91b541a9d7f3bba143ceac34ab2/modules/react/src/deckgl.js#L71-L72
@@ -2228,15 +2238,10 @@ declare module '@deck.gl/core/lib/deck' {
     onWebGLInitialized: (gl: WebGLRenderingContext) => any;
     onViewStateChange: (args: {
       viewState: any;
-      interactionState: {
-        inTransition?: boolean;
-        isDragging?: boolean;
-        isPanning?: boolean;
-        isRotating?: boolean;
-        isZooming?: boolean;
-      };
+      interactionState: InteractionState;
       oldViewState: any;
     }) => any;
+    onInteractionStateChange(interactionState: InteractionState): void;
     onHover: <D>(info: PickInfo<D>, e: MouseEvent) => any;
     onClick: <D>(info: PickInfo<D>, e: MouseEvent) => any;
     onDragStart: <D>(info: PickInfo<D>, e: MouseEvent) => any;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1609,7 +1609,7 @@ declare module '@deck.gl/core/controllers/transition-manager' {
 //https://github.com/visgl/deck.gl/blob/master/docs/api-reference/core/controller.md
 declare module '@deck.gl/core/controllers/controller' {
   import { InteractionState } from '@deck.gl/core/lib/deck';
-  
+
   export interface ControllerOptions {
     scrollZoom?:
       | boolean
@@ -2108,14 +2108,14 @@ declare module '@deck.gl/core/lib/deck' {
   import Controller, { ControllerOptions } from '@deck.gl/core/controllers/controller';
   import Effect from '@deck.gl/core/lib/effect';
   import Layer from '@deck.gl/core/lib/layer';
-  import LayerManager from "@deck.gl/core/lib/layer-manager";
-	import Tooltip from "@deck.gl/core/lib/tooltip";
+  import LayerManager from '@deck.gl/core/lib/layer-manager';
+  import Tooltip from '@deck.gl/core/lib/tooltip';
   import View from '@deck.gl/core/views/view';
   import Viewport from '@deck.gl/core/viewports/viewport';
   import TransitionInterpolator from '@deck.gl/core/transitions/transition-interpolator';
   import { TRANSITION_EVENTS } from '@deck.gl/core/controllers/transition-manager';
   import { Position } from '@deck.gl/core/utils/positions';
-  import { AnimationLoop } from "@luma.gl/core";
+  import { AnimationLoop } from '@luma.gl/core';
 
   export interface InteractiveState {
     isDragging: boolean;
@@ -2183,13 +2183,13 @@ declare module '@deck.gl/core/lib/deck' {
     eventManager: object;
   }
 
-	export interface InteractionState {
-		inTransition?: boolean;
-		isDragging?: boolean;
-		isPanning?: boolean;
-		isRotating?: boolean;
-		isZooming?: boolean;
-	}
+  export interface InteractionState {
+    inTransition?: boolean;
+    isDragging?: boolean;
+    isPanning?: boolean;
+    isRotating?: boolean;
+    isZooming?: boolean;
+  }
 
   export interface DeckProps<T = ContextProviderValue> {
     //https://deck.gl/#/documentation/deckgl-api-reference/deck?section=properties
@@ -2236,11 +2236,7 @@ declare module '@deck.gl/core/lib/deck' {
 
     //Event Callbacks
     onWebGLInitialized: (gl: WebGLRenderingContext) => any;
-    onViewStateChange: (args: {
-      viewState: any;
-      interactionState: InteractionState;
-      oldViewState: any;
-    }) => any;
+    onViewStateChange: (args: { viewState: any; interactionState: InteractionState; oldViewState: any }) => any;
     onInteractionStateChange(interactionState: InteractionState): void;
     onHover: <D>(info: PickInfo<D>, e: MouseEvent) => any;
     onClick: <D>(info: PickInfo<D>, e: MouseEvent) => any;
@@ -2261,11 +2257,11 @@ declare module '@deck.gl/core/lib/deck' {
 
   export default class Deck<T = ContextProviderValue> {
     constructor(props: Partial<DeckProps<T>>);
-		animationLoop: AnimationLoop;
+    animationLoop: AnimationLoop;
     canvas: HTMLCanvasElement;
     eventManager: any;
-		layerManager: LayerManager;
-		tooltip: Tooltip;
+    layerManager: LayerManager;
+    tooltip: Tooltip;
     viewState: any;
     width: number;
     height: number;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -94,6 +94,7 @@ declare module '@deck.gl/core/utils/assert' {
   export default function assert(condition: any, message: any): void;
 }
 declare module '@deck.gl/core/shaderlib/project/viewport-uniforms' {
+  import { Matrix4 } from '@math.gl/core';
   export function getOffsetOrigin(
     viewport: any,
     coordinateSystem: any,
@@ -124,7 +125,7 @@ declare module '@deck.gl/core/shaderlib/project/viewport-uniforms' {
   }?: {
     viewport: any;
     devicePixelRatio?: number;
-    modelMatrix?: any;
+    modelMatrix?: Matrix4;
     coordinateSystem?: number;
     coordinateOrigin: number[];
     wrapLongitude?: boolean;
@@ -307,6 +308,7 @@ declare module '@deck.gl/core/effects/lighting/lighting-effect' {
 }
 declare module '@deck.gl/core/shaderlib/project/project-functions' {
   import { Position } from '@deck.gl/core/utils/positions';
+  import { Matrix4 } from '@math.gl/core';
   export function getWorldPosition(
     position: Position,
     {
@@ -317,7 +319,7 @@ declare module '@deck.gl/core/shaderlib/project/project-functions' {
       offsetMode,
     }: {
       viewport: any;
-      modelMatrix: any;
+      modelMatrix: Matrix4;
       coordinateSystem: any;
       coordinateOrigin: any;
       offsetMode: any;
@@ -979,6 +981,7 @@ declare module '@deck.gl/core/lib/layer' {
   import LayerManager from '@deck.gl/core/lib/layer-manager';
   import Viewport from '@deck.gl/core/viewports/viewport';
   import { Position } from '@deck.gl/core/utils/positions';
+  import { Matrix4 } from '@math.gl/core';
 
   export interface LayerContext {
     layerManager: LayerManager;
@@ -1054,7 +1057,7 @@ declare module '@deck.gl/core/lib/layer' {
     coordinateSystem?: number;
     coordinateOrigin?: Position;
     wrapLongitude?: boolean;
-    modelMatrix?: number[];
+    modelMatrix?: Matrix4;
 
     //Data Properties
     dataComparator?: (newData: D, oldData: D) => boolean;
@@ -1435,6 +1438,7 @@ declare module '@deck.gl/core/utils/positions' {
 }
 declare module '@deck.gl/core/views/view' {
   import Viewport from '@deck.gl/core/viewports/viewport';
+  import { Matrix4 } from '@math.gl/core';
 
   export interface ViewProps {
     id?: string;
@@ -1458,7 +1462,7 @@ declare module '@deck.gl/core/views/view' {
 
     focalDistance?: number; // Modifier of viewport scale. Corresponds to the number of pixels per meter. Default `1`.
 
-    modelMatrix?: number[]; // A model matrix to be applied to position, to match the layer props API
+    modelMatrix?: Matrix4; // A model matrix to be applied to position, to match the layer props API
 
     type?: typeof Viewport; // Internal: Viewport Type
   }

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1118,7 +1118,7 @@ declare module '@deck.gl/core/lib/layer' {
     getAttributeManager(): any;
     getCurrentLayer(): any;
     getLoadOptions(): any;
-    project(xyz: any): any[];
+    project(xyz: [number, number, number]): [number, number, number];
     unproject(xy: any): any;
     projectPosition(xyz: any): any;
     use64bitPositions(): boolean;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1335,6 +1335,7 @@ declare module '@deck.gl/core/viewports/viewport' {
   }
 }
 declare module '@deck.gl/core/lib/layer-manager' {
+  import { Layer } from '@deck.gl/core';
   export default class LayerManager {
     constructor(
       gl: any,
@@ -1355,7 +1356,7 @@ declare module '@deck.gl/core/lib/layer-manager' {
     needsUpdate(): any;
     setNeedsRedraw(reason: any): void;
     setNeedsUpdate(reason: any): void;
-    getLayers({ layerIds }?: { layerIds?: any }): any;
+    getLayers({ layerIds }?: { layerIds?: any }): Layer<any, any>[];
     setProps(props: any): void;
     setLayers(newLayers: any, forceUpdate?: boolean): this;
     updateLayers(): void;
@@ -1368,6 +1369,7 @@ declare module '@deck.gl/core/lib/layer-manager' {
     _transferLayerState(oldLayer: any, newLayer: any): void;
     _updateLayer(layer: any): void;
     _finalizeLayer(layer: any): void;
+    layers: Layer<any, any>[];
   }
 }
 declare module '@deck.gl/core/utils/deep-equal' {

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2105,6 +2105,8 @@ declare module '@deck.gl/core/lib/deck' {
   import Controller, { ControllerOptions } from '@deck.gl/core/controllers/controller';
   import Effect from '@deck.gl/core/lib/effect';
   import Layer from '@deck.gl/core/lib/layer';
+  import LayerManager from "@deck.gl/core/lib/layer-manager";
+	import Tooltip from "@deck.gl/core/lib/tooltip";
   import View from '@deck.gl/core/views/view';
   import Viewport from '@deck.gl/core/viewports/viewport';
   import TransitionInterpolator from '@deck.gl/core/transitions/transition-interpolator';
@@ -2255,6 +2257,9 @@ declare module '@deck.gl/core/lib/deck' {
     constructor(props: Partial<DeckProps<T>>);
 		animationLoop: AnimationLoop;
     canvas: HTMLCanvasElement;
+    eventManager: any;
+		layerManager: LayerManager;
+		tooltip: Tooltip;
     viewState: any;
     width: number;
     height: number;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2110,6 +2110,7 @@ declare module '@deck.gl/core/lib/deck' {
   import TransitionInterpolator from '@deck.gl/core/transitions/transition-interpolator';
   import { TRANSITION_EVENTS } from '@deck.gl/core/controllers/transition-manager';
   import { Position } from '@deck.gl/core/utils/positions';
+  import { AnimationLoop } from "@luma.gl/core";
 
   export interface InteractiveState {
     isDragging: boolean;
@@ -2252,6 +2253,7 @@ declare module '@deck.gl/core/lib/deck' {
 
   export default class Deck<T = ContextProviderValue> {
     constructor(props: Partial<DeckProps<T>>);
+		animationLoop: AnimationLoop;
     canvas: HTMLCanvasElement;
     viewState: any;
     width: number;

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2097,6 +2097,7 @@ declare module '@deck.gl/core/lib/deck-picker' {
 declare module '@deck.gl/core/lib/tooltip' {
   export default class Tooltip {
     constructor(canvas: any);
+    el: HTMLElement;
     setTooltip(displayInfo: any, x: any, y: any): void;
     remove(): void;
   }

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -320,7 +320,7 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
     D,
     P
   > {
-    getShaders(): any;
+    getShaders(id: any): any;
     initializeState(params: any): void;
     draw({ uniforms }: { uniforms: any }): void;
     _getModel(gl: any): any;

--- a/deck.gl__react/index.d.ts
+++ b/deck.gl__react/index.d.ts
@@ -45,7 +45,7 @@ declare module '@deck.gl/react/utils/extract-styles' {
 declare module '@deck.gl/react/deckgl' {
   import Deck, { ContextProviderValue, DeckProps } from '@deck.gl/core/lib/deck';
   export type DeckGLProps<T = ContextProviderValue> = Partial<DeckProps<T>>;
-  import { ReactElement } from 'react';
+  import { ReactElement, RefObject } from 'react';
   export default class DeckGL<T = ContextProviderValue> extends React.Component<DeckGLProps<T>> {
     constructor(props: DeckGLProps<T>);
     componentDidMount(): void;
@@ -60,6 +60,7 @@ declare module '@deck.gl/react/deckgl' {
     _parseJSX(props: any): any;
     _updateFromProps(props: any): void;
     render(): ReactElement;
+    _containerRef: RefObject<HTMLElement>;
     deck: Deck;
   }
 }


### PR DESCRIPTION
A collection of small touch-ups I've collected over time. Just running down a commit summary:
- <s>Removes math.gl and luma.gl types because they now have their own</s>
- Adds "_containerRef" to the DeckGL class
- LayerManager returns `Layer<any, any>` to better match all Layers.
- Uses math.gl's `Matrix4` for instances of `modelMatrix`
- Adds animationLoop, eventManager, layerManager, tooltip to Deck class
- Adds "el" to the Tooltip class
- Extracts an "InteractionState" type and uses it accordingly
- Re-adds the "id" parameter to Scatterplot.getShaders