### PR TITLE
TRANSITION_EVENTS as enum

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1580,11 +1580,12 @@ declare module '@deck.gl/core/transitions/linear-interpolator' {
   }
 }
 declare module '@deck.gl/core/controllers/transition-manager' {
-  export const TRANSITION_EVENTS: {
-    BREAK: number;
-    SNAP_TO_END: number;
-    IGNORE: number;
-  };
+  export enum TRANSITION_EVENTS {
+    BREAK = 1,
+    SNAP_TO_END = 2,
+    IGNORE = 3
+  }
+
   export default class TransitionManager {
     constructor(ControllerState: any, props?: {});
     finalize(): void;
@@ -1673,6 +1674,7 @@ declare module '@deck.gl/core/controllers/map-controller' {
   import Controller from '@deck.gl/core/controllers/controller';
   import ViewState from '@deck.gl/core/controllers/view-state';
   import LinearInterpolator from '@deck.gl/core/transitions/linear-interpolator';
+  import { TRANSITION_EVENTS } from '@deck.gl/core/controllers/transition-manager';
   export const MAPBOX_LIMITS: {
     minZoom: number;
     maxZoom: number;
@@ -1830,7 +1832,7 @@ declare module '@deck.gl/core/controllers/map-controller' {
       transitionDuration: number;
       transitionEasing: (t: any) => any;
       transitionInterpolator: LinearInterpolator;
-      transitionInterruption: number;
+      transitionInterruption: TRANSITION_EVENTS;
     };
     _onPanRotate(event: any): false | void;
   }
@@ -2141,7 +2143,7 @@ declare module '@deck.gl/core/lib/deck' {
     transitionDuration?: number | string;
     transitionEasing?: (x: number) => number;
     transitionInterpolator?: TransitionInterpolator;
-    transitionInterruption?: typeof TRANSITION_EVENTS[keyof typeof TRANSITION_EVENTS];
+    transitionInterruption?: TRANSITION_EVENTS;
     onTransitionStart?: () => void;
     onTransitionInterrupt?: () => void;
     onTransitionEnd?: () => void;
@@ -2412,6 +2414,7 @@ declare module '@deck.gl/core/controllers/orbit-controller' {
   import Controller from '@deck.gl/core/controllers/controller';
   import ViewState from '@deck.gl/core/controllers/view-state';
   import LinearInterpolator from '@deck.gl/core/transitions/linear-interpolator';
+  import { TRANSITION_EVENTS } from '@deck.gl/core/controllers/transition-manager';
   export class OrbitState extends ViewState {
     constructor({
       ViewportType,
@@ -2526,7 +2529,7 @@ declare module '@deck.gl/core/controllers/orbit-controller' {
       transitionDuration: number;
       transitionEasing: (t: any) => any;
       transitionInterpolator: LinearInterpolator;
-      transitionInterruption: number;
+      transitionInterruption: TRANSITION_EVENTS;
     };
   }
 }
@@ -2554,6 +2557,7 @@ declare module '@deck.gl/core/views/orbit-view' {
 declare module '@deck.gl/core/controllers/orthographic-controller' {
   import Controller from '@deck.gl/core/controllers/controller';
   import LinearInterpolator from '@deck.gl/core/transitions/linear-interpolator';
+  import { TRANSITION_EVENTS } from '@deck.gl/core/controllers/transition-manager';
   export default class OrthographicController extends Controller {
     constructor(props: any);
     _onPanRotate(event: any): boolean | void;
@@ -2561,7 +2565,7 @@ declare module '@deck.gl/core/controllers/orthographic-controller' {
       transitionDuration: number;
       transitionEasing: (t: any) => any;
       transitionInterpolator: LinearInterpolator;
-      transitionInterruption: number;
+      transitionInterruption: TRANSITION_EVENTS;
     };
   }
 }

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1585,7 +1585,6 @@ declare module '@deck.gl/core/controllers/transition-manager' {
     SNAP_TO_END = 2,
     IGNORE = 3
   }
-
   export default class TransitionManager {
     constructor(ControllerState: any, props?: {});
     finalize(): void;


### PR DESCRIPTION
https://github.com/visgl/deck.gl/blob/master/modules/core/src/controllers/transition-manager.ts#L9-L15

I'm not sure if typing library is allowed to have literal. Here is my changes
```ts
  export enum TRANSITION_EVENTS {
    BREAK = 1,
    SNAP_TO_END = 2,
    IGNORE = 3
  }
```
