### PR TITLE
WidthUnits/radiusUnits: add new 'common' unit type

### DIFF
--- a/deck.gl/index.d.ts
+++ b/deck.gl/index.d.ts
@@ -54,6 +54,7 @@ declare module 'deck.gl' {
     Position,
     Position2D,
     Position3D,
+    UNIT
   } from '@deck.gl/core';
   export {
     ArcLayer,

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -1016,7 +1016,7 @@ declare module '@deck.gl/core/lib/layer' {
     (o: PickInfo<D>, e: HammerInput): any;
   }
   export type DataSet<D> = Iterable<D>;
-  export type WidthUnits = 'meters' | 'pixels';
+  export type WidthUnits = 'meters' | 'common' | 'pixels';
 
   export interface ObjectInfo<D, T> {
     // the index of the current iteration

--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -982,6 +982,7 @@ declare module '@deck.gl/core/lib/layer' {
   import Viewport from '@deck.gl/core/viewports/viewport';
   import { Position } from '@deck.gl/core/utils/positions';
   import { Matrix4 } from '@math.gl/core';
+  import { UNIT } from '@deck.gl/core/lib/constants';
 
   export interface LayerContext {
     layerManager: LayerManager;
@@ -1016,7 +1017,7 @@ declare module '@deck.gl/core/lib/layer' {
     (o: PickInfo<D>, e: HammerInput): any;
   }
   export type DataSet<D> = Iterable<D>;
-  export type WidthUnits = 'meters' | 'common' | 'pixels';
+  export type WidthUnits = keyof typeof UNIT;
 
   export interface ObjectInfo<D, T> {
     // the index of the current iteration

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -296,6 +296,7 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
   import { LayerProps, WidthUnits } from '@deck.gl/core/lib/layer';
   import { Position } from '@deck.gl/core/utils/positions';
   import { RGBAColor } from '@deck.gl/core/utils/color';
+  export { UNIT } from '@deck.gl/core/lib/constants';
   export interface ScatterplotLayerProps<D> extends LayerProps<D> {
     radiusScale?: number;
     lineWidthUnits?: WidthUnits;
@@ -306,7 +307,7 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
     radiusMaxPixels?: number;
     lineWidthMinPixels?: number;
     lineWidthMaxPixels?: number;
-    radiusUnits?: 'meters' | 'common' | 'pixels';
+    radiusUnits?: keyof typeof UNIT;
 
     //Data Accessors
     getPosition?: (d: D) => Position;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -306,7 +306,7 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
     radiusMaxPixels?: number;
     lineWidthMinPixels?: number;
     lineWidthMaxPixels?: number;
-    radiusUnits?: 'meters' | 'pixels';
+    radiusUnits?: 'meters' | 'common' | 'pixels';
 
     //Data Accessors
     getPosition?: (d: D) => Position;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -296,7 +296,7 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
   import { LayerProps, WidthUnits } from '@deck.gl/core/lib/layer';
   import { Position } from '@deck.gl/core/utils/positions';
   import { RGBAColor } from '@deck.gl/core/utils/color';
-  export { UNIT } from '@deck.gl/core/lib/constants';
+  import { UNIT } from '@deck.gl/core/lib/constants';
   export interface ScatterplotLayerProps<D> extends LayerProps<D> {
     radiusScale?: number;
     lineWidthUnits?: WidthUnits;


### PR DESCRIPTION
A new `common` unit type has been added which is now available in addition to the previously available types `meters` and `pixels`.

See [supported units docs](https://deck.gl/docs/developer-guide/coordinate-systems#supported-units) and also [scatterplot docs](https://deck.gl/docs/api-reference/layers/scatterplot-layer#radiusunits).