### PR TITLE
GeoJson layer props

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -925,7 +925,7 @@ declare module '@deck.gl/core/lifecycle/component' {
   import { LayerContext } from '@deck.gl/core/lib/layer';
   export default class Component<P> {
     constructor(props: P, ...additionalProps: P[]);
-    clone(newProps: P): any;
+    clone(newProps?: Partial<P>): any;
     get stats(): any;
     _initState(): void;
 
@@ -1590,7 +1590,7 @@ declare module '@deck.gl/core/controllers/transition-manager' {
   export enum TRANSITION_EVENTS {
     BREAK = 1,
     SNAP_TO_END = 2,
-    IGNORE = 3
+    IGNORE = 3,
   }
   export default class TransitionManager {
     constructor(ControllerState: any, props?: {});
@@ -2198,7 +2198,7 @@ declare module '@deck.gl/core/lib/deck' {
     // https://github.com/visgl/deck.gl/blob/e948740f801cf91b541a9d7f3bba143ceac34ab2/modules/react/src/deckgl.js#L71-L72
     width: string | number;
     height: string | number;
-    layers: Layer<any>[];
+    layers: (Layer<any> | undefined | null | false)[];
     layerFilter: (args: { layer: Layer<any>; viewport: Viewport; isPicking: boolean; renderPass: string }) => boolean;
     getCursor: (interactiveState: InteractiveState) => string;
     views: View[];

--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -200,7 +200,7 @@ declare module '@deck.gl/geo-layers/tile-layer/tile-layer' {
       url: string;
       bbox: any;
       signal: AbortSignal;
-    }) => D[] | Promise<D[]> | null;
+    }) => D[] | null | Promise<D[] | null>;
     tileSize?: number;
     maxZoom?: number | null;
     minZoom?: number;

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -298,6 +298,7 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
   import { RGBAColor } from '@deck.gl/core/utils/color';
   import { UNIT } from '@deck.gl/core/lib/constants';
   export interface ScatterplotLayerProps<D> extends LayerProps<D> {
+    radiusUnits?: keyof typeof UNIT;
     radiusScale?: number;
     lineWidthUnits?: WidthUnits;
     lineWidthScale?: number;
@@ -307,7 +308,8 @@ declare module '@deck.gl/layers/scatterplot-layer/scatterplot-layer' {
     radiusMaxPixels?: number;
     lineWidthMinPixels?: number;
     lineWidthMaxPixels?: number;
-    radiusUnits?: keyof typeof UNIT;
+    billboard?: boolean;
+    antialiasing?: boolean;
 
     //Data Accessors
     getPosition?: (d: D) => Position;
@@ -680,34 +682,95 @@ declare module '@deck.gl/layers/geojson-layer/geojson-layer' {
   import { CompositeLayerProps } from '@deck.gl/core/lib/composite-layer';
   import { RGBAColor } from '@deck.gl/core/utils/color';
   import { WidthUnits } from '@deck.gl/core/lib/layer';
+  import { ScatterplotLayerProps } from '@deck.gl/layers/scatterplot-layer/scatterplot-layer';
+  import { IconLayerProps } from '@deck.gl/layers/icon-layer/icon-layer';
+  import { TextLayerProps } from '@deck.gl/layers/text-layer/text-layer';
+
   export interface GeoJsonLayerProps<D> extends CompositeLayerProps<D> {
-    //Render Options
+    // Render Options
+    // Fill Options
     filled?: boolean;
+    // Stroke Options
     stroked?: boolean;
-    extruded?: boolean;
-    wireframe?: boolean;
     lineWidthUnits?: WidthUnits;
     lineWidthScale?: number;
     lineWidthMinPixels?: number;
     lineWidthMaxPixels?: number;
+    lineCapRounded?: boolean;
     lineJointRounded?: boolean;
     lineMiterLimit?: number;
+    lineBillboard?: boolean;
+    // 3D Options
+    extruded?: boolean;
+    wireframe?: boolean;
     elevationScale?: number;
-    pointRadiusScale?: number;
-    pointRadiusUnits?: string;
-    pointRadiusMinPixels?: number;
-    pointRadiusMaxPixels?: number;
     material?: any;
 
     //Data Accessors
-    getLineColor?: ((d: D) => RGBAColor) | RGBAColor;
     getFillColor?: ((d: D) => RGBAColor) | RGBAColor;
-    getPointRadius?: ((d: D) => number) | number;
+    getLineColor?: ((d: D) => RGBAColor) | RGBAColor;
     getLineWidth?: ((d: D) => number) | number;
     getElevation?: ((d: D) => number) | number;
 
-    // getRadius is deprecated since deck.gl v8.5, use getPointRadius instead
-    getRadius?: ((d: D) => number) | number;
+    // Point Options
+    pointType?: string;
+
+    // pointType:circle Options (ScatterplotLayer Props)
+    /**
+     * @deprecated
+     * getRadius is deprecated since deck.gl v8.5, use {@link getPointRadius} instead
+     * */
+    getRadius?: ScatterplotLayerProps<D>['getRadius'];
+    getPointRadius?: ScatterplotLayerProps<D>['getRadius'];
+    pointRadiusUnits?: ScatterplotLayerProps<D>['radiusUnits'];
+    pointRadiusScale?: ScatterplotLayerProps<D>['radiusScale'];
+    pointRadiusMinPixels?: ScatterplotLayerProps<D>['radiusMinPixels'];
+    pointRadiusMaxPixels?: ScatterplotLayerProps<D>['radiusMaxPixels'];
+    pointAntialiasing?: ScatterplotLayerProps<D>['antialiasing'];
+    pointBillboard?: ScatterplotLayerProps<D>['billboard'];
+
+    // pointType:icon Options (IconLayer Props)
+    iconAtlas?: IconLayerProps<D>['iconAtlas'];
+    iconMapping?: IconLayerProps<D>['iconMapping'];
+    getIcon?: IconLayerProps<D>['getIcon'];
+    getIconSize?: IconLayerProps<D>['getSize'];
+    getIconColor?: IconLayerProps<D>['getColor'];
+    getIconAngle?: IconLayerProps<D>['getAngle'];
+    getIconPixelOffset?: IconLayerProps<D>['getPixelOffset'];
+    iconSizeUnits?: IconLayerProps<D>['sizeUnits'];
+    iconSizeScale?: IconLayerProps<D>['sizeScale'];
+    iconSizeMinPixels?: IconLayerProps<D>['sizeMinPixels'];
+    iconSizeMaxPixels?: IconLayerProps<D>['sizeMaxPixels'];
+    iconBillboard?: IconLayerProps<D>['billboard'];
+    iconAlphaCutoff?: IconLayerProps<D>['alphaCutoff'];
+
+    // pointType:text Options (TextLayer Props)
+    getText?: TextLayerProps<D>['getText'];
+    getTextColor?: TextLayerProps<D>['getColor'];
+    getTextAngle?: TextLayerProps<D>['getAngle'];
+    getTextSize?: TextLayerProps<D>['getSize'];
+    getTextAnchor?: TextLayerProps<D>['getTextAnchor'];
+    getTextAlignmentBaseline?: TextLayerProps<D>['getAlignmentBaseline'];
+    getTextPixelOffset?: TextLayerProps<D>['getPixelOffset'];
+    getTextBackgroundColor?: TextLayerProps<D>['getBackgroundColor'];
+    getTextBorderColor?: TextLayerProps<D>['getBorderColor'];
+    getTextBorderWidth?: TextLayerProps<D>['getBorderWidth'];
+    textSizeUnits?: TextLayerProps<D>['sizeUnits'];
+    textSizeScale?: TextLayerProps<D>['sizeScale'];
+    textSizeMinPixels?: TextLayerProps<D>['sizeMinPixels'];
+    textSizeMaxPixels?: TextLayerProps<D>['sizeMaxPixels'];
+    textCharacterSet?: TextLayerProps<D>['characterSet'];
+    textFontFamily?: TextLayerProps<D>['fontFamily'];
+    textFontWeight?: TextLayerProps<D>['fontWeight'];
+    textLineHeight?: TextLayerProps<D>['lineHeight'];
+    textMaxWidth?: TextLayerProps<D>['maxWidth'];
+    textWordBreak?: TextLayerProps<D>['wordBreak'];
+    textBackground?: TextLayerProps<D>['background'];
+    textBackgroundPadding?: TextLayerProps<D>['backgroundPadding'];
+    textOutlineColor?: TextLayerProps<D>['outlineColor'];
+    textOutlineWidth?: TextLayerProps<D>['outlineWidth'];
+    textBillboard?: TextLayerProps<D>['billboard'];
+    textFontSettings?: TextLayerProps<D>['fontSettings'];
   }
   export default class GeoJsonLayer<D, P extends GeoJsonLayerProps<D> = GeoJsonLayerProps<D>> extends CompositeLayer<
     D,
@@ -910,6 +973,8 @@ declare module '@deck.gl/layers/text-layer/text-layer' {
     fontSettings?: FontSettings;
     wordBreak?: 'break-all' | 'break-word';
     maxWidth?: number;
+    outlineColor?: RGBAColor;
+    outlineWidth?: number;
 
     //Data Accessors
     getText?: (x: D) => string;
@@ -922,8 +987,10 @@ declare module '@deck.gl/layers/text-layer/text-layer' {
     getTextAnchor?: ((x: D) => TextAnchor) | TextAnchor;
     getAlignmentBaseline?: ((x: D) => AlignmentBaseline) | AlignmentBaseline;
     getPixelOffset?: ((x: D) => number[]) | number[];
-    outlineColor?: RGBAColor;
-    outlineWidth?: number;
+
+    getBackgroundColor?: ((d: D) => RGBAColor) | RGBAColor;
+    getBorderColor?: ((d: D) => RGBAColor) | RGBAColor;
+    getBorderWidth?: ((d: D) => number) | number;
   }
   export default class TextLayer<D, P extends TextLayerProps<D> = TextLayerProps<D>> extends CompositeLayer<D, P> {
     initializeState(params: any): void;


### PR DESCRIPTION
- Adapt props from sub-layers to GeoJson layer
- Layer clone accepts partial props
- Deck layers prop accepts falsy item
- TileLayer `getTileData` returns `Promise` with falsy value
- Add missing props to ScatterplotLayerProps. related to #227
- Add missing props to TextLayerProps