### PR TITLE
Remove unused param and doc from solid-polygon-layer's normalize function

### DIFF
--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -484,14 +484,11 @@ declare module '@deck.gl/layers/solid-polygon-layer/polygon' {
    * Normalize any polygon representation into the "complex flat" format
    * @param {Array|Object} polygon
    * @param {Number} positionSize - size of a position, 2 (xy) or 3 (xyz)
-   * @param {Number} [vertexCount] - pre-computed vertex count in the polygon.
-   *   If provided, will skip counting.
    * @return {Object} - {positions: <Float64Array>, holeIndices: <Array|null>}
    */
   export function normalize(
     polygon: any,
-    positionSize: any,
-    vertexCount: any
+    positionSize: number
   ):
     | Float64Array
     | {


### PR DESCRIPTION
Remove param and corresponding doc to make normalize function correct.
Add number type for number input.
Based on issue: https://github.com/visgl/deck.gl/issues/6839
