### PR TITLE
Fixed path props type in constructor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ test-out
 
 # Editors
 .vscode
+.idea

--- a/deck.gl__layers/index.d.ts
+++ b/deck.gl__layers/index.d.ts
@@ -465,7 +465,7 @@ declare module '@deck.gl/layers/path-layer/path-layer' {
     getWidth?: ((d: D) => number) | number;
   }
   export default class PathLayer<D, P extends PathLayerProps<D> = PathLayerProps<D>> extends Layer<D, P> {
-    constructor(props: PathLayerProps<D>);
+    constructor(props: P);
     getShaders(): any;
     initializeState(params: any): void;
     draw({ uniforms }: { uniforms: any }): void;


### PR DESCRIPTION
Fixed path props type correctness in constructor. As far as I understand, all props are passed to the constructor, not a subset, so generic `P` from `P extends PathLayerProps<D>` should be passed instead of `PathLayerProps<D>`.

`P` basically differs from normal props when an extensions is used, for example the `PathStyleExtension`, that adds more properties as valid on PathLayerProps.

_*Note that I have also added on .gitignore the /.idea fodler that are the editor settings from Jetbrains editors._