### PR TITLE
fix/missing fadeTrail property in TripsLayer

### DIFF
--- a/deck.gl__geo-layers/index.d.ts
+++ b/deck.gl__geo-layers/index.d.ts
@@ -239,6 +239,7 @@ declare module '@deck.gl/geo-layers/trips-layer/trips-layer' {
   export interface TripsLayerProps<D> extends PathLayerProps<D> {
     //Render Options
     currentTime?: number;
+    fadeTrail?: boolean;
     trailLength?: number;
 
     //Data Accessors


### PR DESCRIPTION
Adding the property [`fadeTrail`](https://deck.gl/docs/api-reference/geo-layers/trips-layer#fadetrail) that was missing in the TripsLayer.