### PR TITLE
Add drawPickingColors to DeckProps

### DIFF
--- a/deck.gl__core/index.d.ts
+++ b/deck.gl__core/index.d.ts
@@ -2233,6 +2233,7 @@ declare module '@deck.gl/core/lib/deck' {
     _framebuffer: any;
     parameters: object;
     debug: boolean;
+    drawPickingColors: boolean;
     _animate: boolean;
     _pickable: boolean;
 


### PR DESCRIPTION
Add `drawPickingColors` to DeckProps

ref:
https://github.com/visgl/deck.gl/blob/8.8-release/modules/core/src/lib/deck.ts#L225